### PR TITLE
Fix link to Julython org on Github.

### DIFF
--- a/july/templates/index.html
+++ b/july/templates/index.html
@@ -168,7 +168,7 @@
             <div class="span4 section-blurb">
               <h3>Github</h3>
               <p>We love sharing code, follow us on
-                  <a href="https://github.com/organizations/julython">github</a>.</p>
+                  <a href="http://github.com/julython">github</a>.</p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Thanks for this!

From what I understand, only users in the organization can access http://github.com/organizations/(organization_name), this commit changes the URL to a universally accessible one.
