### PR TITLE
Added a slash to the end of the user_profile entry in july/people/urls.py

### DIFF
--- a/july/people/urls.py
+++ b/july/people/urls.py
@@ -3,7 +3,7 @@ from django.conf.urls.defaults import patterns, url
 urlpatterns = patterns('july.people.views',
     url(r'^location/$', 'locations', name='locations'),
     url(r'^location/(?P<location_slug>[a-zA-Z0-9\-]+)/$', 'users_by_location', name='member-list'),
-    url(r'^(?P<username>[a-zA-Z0-9_]+)$', 'user_profile', name='member-profile'),
+    url(r'^(?P<username>[a-zA-Z0-9_]+)/$', 'user_profile', name='member-profile'),
     url(r'^(?P<username>[a-zA-Z0-9_]+)/edit/$', 'edit_profile', name='edit-profile'),
     url(r'^(?P<username>[a-zA-Z0-9_]+)/email/(?P<email>.*)$', 'delete_email', name='delete-email'),
 )


### PR DESCRIPTION
If you are on the Edit Profile page and you click the Cancel button you get a 404 error, because the july/people/urls.py entry for the user_profile view does not expect a slash at the end of the url.  This pull requests adds the required slash so that the Cancel button on the Edit Profile page works.
