### PR TITLE
Adjust auth to newest versions of django-social-auth...

### DIFF
--- a/july/auth/github.py
+++ b/july/auth/github.py
@@ -1,6 +1,5 @@
 import logging
 
-from social_auth.backends import USERNAME
 from social_auth.backends.contrib import github
 from july.people.models import Location
 
@@ -10,7 +9,7 @@ class GithubBackend(github.GithubBackend):
     def get_user_details(self, response):
         """Return user details from Github account"""
         data = {
-            USERNAME: response.get('login'),
+            'username': response.get('login'),
             'email': response.get('email') or '',
             'fullname': response.get('name', 'Secret Agent'),
             'last_name': '',

--- a/july/auth/twitter.py
+++ b/july/auth/twitter.py
@@ -2,7 +2,6 @@ __author__ = 'Kevin'
 
 import logging
 
-from social_auth.backends import USERNAME
 from social_auth.backends import twitter
 from july.people.models import Location
 
@@ -12,7 +11,7 @@ class TwitterBackend(twitter.TwitterBackend):
     def get_user_details(self, response):
         """Return user details from Twitter account"""
         data = {
-            USERNAME: response['screen_name'],
+            'username': response['screen_name'],
             'email': '',  # not supplied
             'fullname': response['name'],
             'last_name': '',


### PR DESCRIPTION
In newest versions of django-social-auth, USERNAME value is dropped and we should use string directly.

More in commit: https://github.com/omab/django-social-auth/commit/cce0406a6ce1b8fcc709bdfcb5c68ac3269a272d
