### PR TITLE
Profile.url doesn't redirect properly 'without http://'

### DIFF
--- a/july/templates/july/user_detail.html
+++ b/july/templates/july/user_detail.html
@@ -34,8 +34,12 @@
             <li><a href="http://github.com/{{ profile.github.uid }}"><i class="icon-globe"></i> {% trans "Follow on Github" %}</a></li>
             {% endif %}
             {% if profile.url %}
-            <li><a href="{{ profile.url }}"><i class="icon-globe"></i> {{profile.url}}</a></li>
-            {% endif %}
+				{% if 'http://' in profile.url %}
+            	<li><a href="{{ profile.url }} "><i class="icon-globe"></i> {{profile.url}}</a></li>
+				{% else %}
+				<li><a href="http://{{ profile.url }} "><i class="icon-globe"></i> {{profile.url}}</a></li>
+				{% endif %}
+			{% endif %}
             {% if profile.location %}
             <li><a href="{% url 'location-detail' profile.location.slug %}"><i class="icon-map-marker"></i> {{ profile.location}}</a></li>
             {% endif %}


### PR DESCRIPTION
If a user inputs a personal url without http:// the template is rendered with {baseurl} + users profile.url. 

Example: if you have www.christopherjaynes.com or christopherjaynes.com on click you are directed to

http://www.julython.org/topherjaynes/www.christopherjaynes.com

and 

http://www.julython.org/topherjaynes/christopherjaynes.com

Live examples:
http://www.julython.org/topherjaynes/
http://www.julython.org/simon_weber/

Should be handled when data is added to DB, but since it's close to the end of the month added to template so you don't have to clean current data. 
