### PR TITLE
remove setting global console variable (breaks firefox 30)

### DIFF
--- a/assets/js/src/index.js
+++ b/assets/js/src/index.js
@@ -1,6 +1,5 @@
 /* VARIOUS HELPERS for HOMEPAGE */
 if (!$) { var $ = null; }
-if (!console) { var console = null; }
 
 var Nav = function(selector, offset) {
   this._selector = selector;


### PR DESCRIPTION
if the global variable console is undefined, null, or false, it is set to null. This seems to break Firefox 30, where for whatever reason one of these conditions meet. If there is no reason for this line, just remove it.

fixes #112
