### PR TITLE
[BugFix] Correct url link by moving context variable above

### DIFF
--- a/july/templates/july/user_detail.html
+++ b/july/templates/july/user_detail.html
@@ -74,6 +74,7 @@
             </li>
             {% endif %}
           </ul>
+          {% url 'edit-profile' username=user.username as edit_profile_url %}
           <div class="tab-content">
             <div class="tab-pane active" id="projects">
               {% include "people/people_projects.html" %}
@@ -82,7 +83,6 @@
               {% include "people/github_projects.html" %}
             </div>
             <div class="tab-pane hidden-phone" id="commits">
-              {% url 'edit-profile' username=user.username as edit_profile_url %}
               <div class="row">
                 <div class="span10">
                   {% if profile.commit_set.count %}


### PR DESCRIPTION
Current - 

![julython](https://cloud.githubusercontent.com/assets/4817493/8457636/22ba60ea-2030-11e5-9e3a-6b806541c6cf.png)

After moving context variable above - 

![julython_link](https://cloud.githubusercontent.com/assets/4817493/8457643/3d750e94-2030-11e5-9df4-d43a608d9c6f.png)

Notice the link url in the lower left. The problem is only in Projects section not in Commit section on user detail page.