### PR TITLE
refactor(handlers): extract shared handler utilities to shared.go

### DIFF
--- a/internal/db/helpers.go
+++ b/internal/db/helpers.go
@@ -30,6 +30,14 @@ func NullUUID() pgtype.UUID {
 	return pgtype.UUID{}
 }
 
+// StringFromNull returns the string value of a nullable text field, or "" if null.
+func StringFromNull(t pgtype.Text) string {
+	if t.Valid {
+		return t.String
+	}
+	return ""
+}
+
 // GetCommitByHash looks up a commit by its hash string.
 func (q *Queries) GetCommitByHashStr(ctx context.Context, hash string) (Commit, error) {
 	return q.GetCommitByHash(ctx, Text(hash))

--- a/internal/handlers/home.go
+++ b/internal/handlers/home.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"time"
 
@@ -131,37 +130,6 @@ func (h *HomeHandler) getRecentCommits(ctx context.Context, gameID uuid.UUID) []
 
 	return commits
 }
-
-func timeAgo(t time.Time) string {
-	now := time.Now()
-	diff := now.Sub(t)
-
-	switch {
-	case diff < time.Minute:
-		return "just now"
-	case diff < time.Hour:
-		mins := int(diff.Minutes())
-		if mins == 1 {
-			return "1 minute ago"
-		}
-		return fmt.Sprintf("%d minutes ago", mins)
-	case diff < 24*time.Hour:
-		hours := int(diff.Hours())
-		if hours == 1 {
-			return "1 hour ago"
-		}
-		return fmt.Sprintf("%d hours ago", hours)
-	case diff < 7*24*time.Hour:
-		days := int(diff.Hours() / 24)
-		if days == 1 {
-			return "1 day ago"
-		}
-		return fmt.Sprintf("%d days ago", days)
-	default:
-		return t.Format("Jan 2")
-	}
-}
-
 func (h *HomeHandler) renderEmptyHome(w http.ResponseWriter, r *http.Request) {
 	days := make([]components.DayCommits, 31)
 	for i := 0; i < 31; i++ {

--- a/internal/handlers/shared.go
+++ b/internal/handlers/shared.go
@@ -2,7 +2,9 @@ package handlers
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/rs/zerolog/log"
 )
@@ -13,5 +15,38 @@ func respondJSON(w http.ResponseWriter, r *http.Request, status int, v any) {
 	w.WriteHeader(status)
 	if err := json.NewEncoder(w).Encode(v); err != nil {
 		log.Ctx(r.Context()).Err(err).Msg("respondJSON")
+	}
+}
+
+var timeAgoNow = time.Now
+
+// timeAgo returns a human-readable string for how long ago a time occurred.
+func timeAgo(t time.Time) string {
+	now := timeAgoNow()
+	diff := now.Sub(t)
+
+	switch {
+	case diff < time.Minute:
+		return "just now"
+	case diff < time.Hour:
+		mins := int(diff.Minutes())
+		if mins == 1 {
+			return "1 minute ago"
+		}
+		return fmt.Sprintf("%d minutes ago", mins)
+	case diff < 24*time.Hour:
+		hours := int(diff.Hours())
+		if hours == 1 {
+			return "1 hour ago"
+		}
+		return fmt.Sprintf("%d hours ago", hours)
+	case diff < 7*24*time.Hour:
+		days := int(diff.Hours() / 24)
+		if days == 1 {
+			return "1 day ago"
+		}
+		return fmt.Sprintf("%d days ago", days)
+	default:
+		return t.Format("Jan 2")
 	}
 }

--- a/internal/handlers/shared_test.go
+++ b/internal/handlers/shared_test.go
@@ -1,0 +1,110 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"july/internal/db"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRespondJSON(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     int
+		value      any
+		wantStatus int
+		wantType   string
+	}{
+		{"ok map", http.StatusOK, map[string]bool{"ok": true}, http.StatusOK, "application/json"},
+		{"created struct", http.StatusCreated, map[string]string{"id": "abc"}, http.StatusCreated, "application/json"},
+		{"no content nil", http.StatusNoContent, nil, http.StatusNoContent, "application/json"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodGet, "/", nil)
+			ctx := context.Background()
+			r = r.WithContext(ctx)
+
+			respondJSON(w, r, tc.status, tc.value)
+
+			require.Equal(t, tc.wantStatus, w.Code)
+			require.Contains(t, w.Header().Get("Content-Type"), tc.wantType)
+		})
+	}
+}
+
+func TestRespondJSON_JSONBody(t *testing.T) {
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r = r.WithContext(context.Background())
+
+	type resp struct {
+		Message string `json:"message"`
+	}
+	respondJSON(w, r, http.StatusOK, resp{Message: "hello"})
+
+	require.Equal(t, `{"message":"hello"}`+"\n", w.Body.String())
+}
+
+func TestTimeAgo(t *testing.T) {
+	fixed := time.Date(2026, 5, 2, 12, 0, 0, 0, time.UTC)
+	orig := timeAgoNow
+	timeAgoNow = func() time.Time { return fixed }
+	defer func() { timeAgoNow = orig }()
+
+	tests := []struct {
+		name     string
+		offset   time.Duration
+		expected string
+	}{
+		{"just now", 0, "just now"},
+		{"30 seconds", 30 * time.Second, "just now"},
+		{"1 minute", time.Minute, "1 minute ago"},
+		{"5 minutes", 5 * time.Minute, "5 minutes ago"},
+		{"59 minutes", 59 * time.Minute, "59 minutes ago"},
+		{"1 hour", time.Hour, "1 hour ago"},
+		{"3 hours", 3 * time.Hour, "3 hours ago"},
+		{"23 hours", 23 * time.Hour, "23 hours ago"},
+		{"1 day", 24 * time.Hour, "1 day ago"},
+		{"5 days", 5 * 24 * time.Hour, "5 days ago"},
+		{"6 days", 6 * 24 * time.Hour, "6 days ago"},
+		{"7 days", 7 * 24 * time.Hour, "Apr 25"}, // default format kicks in
+		{"30 days", 30 * 24 * time.Hour, "Apr 2"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := timeAgo(fixed.Add(-tc.offset))
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestStringFromNull(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    pgtype.Text
+		expected string
+	}{
+		{"valid string", pgtype.Text{String: "hello", Valid: true}, "hello"},
+		{"empty string valid", pgtype.Text{String: "", Valid: true}, ""},
+		{"invalid null", pgtype.Text{String: "hello", Valid: false}, ""},
+		{"empty invalid", pgtype.Text{String: "", Valid: false}, ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := db.StringFromNull(tc.input)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}


### PR DESCRIPTION
Consolidate shared helper functions into a single shared.go file so they can be imported by any handler.

- respondJSON: writes JSON response with status code, logs errors internally via the request-scoped logger (log.Ctx(r.Context()))
- timeAgo: returns human-readable "X ago" string, uses a package variable (timeAgoNow) for testable time mocking
- db.StringFromNull: moved from handlers to db package, lives alongside other pgtype helper functions (Text, NullText, BigInt, UUID)

Tests cover all three functions including edge cases and deterministic timeAgo testing via timeAgoNow override.

Closes #164.