### PR TITLE
feat(db): add player board system

### DIFF
--- a/db/players.sql
+++ b/db/players.sql
@@ -48,3 +48,42 @@ WHERE p.game_id = @game_id
     SELECT CASE WHEN p2.verified_points > 0 THEN p2.verified_points ELSE p2.potential_points END
     FROM players p2 WHERE p2.id = @player_id
   );
+
+-- ============================================
+-- Player Boards (up to 3 active boards)
+-- ============================================
+
+-- name: AssignBoards :one
+-- Update a player's up-to-3 board slots.  NULL arguments leave existing
+-- columns untouched, so callers can update 1, 2, or all 3 boards in one
+-- query without re-reading the player row first.
+UPDATE players
+    SET board_1_id = COALESCE(@board_1_id, board_1_id),
+        board_2_id = COALESCE(@board_2_id, board_2_id),
+        board_3_id = COALESCE(@board_3_id, board_3_id)
+WHERE id = @player_id
+RETURNING *;
+
+-- name: GetPlayerBoardIds :one
+-- Return the 3 board IDs for a player.  Callers can join boards on
+-- these IDs when displaying the leaderboard.
+SELECT p.board_1_id, p.board_2_id, p.board_3_id
+FROM players p
+WHERE p.id = @player_id;
+
+-- name: ListPlayersWithBoards :many
+-- Leaderboard with per-player board totals computed via lateral join.
+-- Projects board_N_id columns directly from players so the lateral
+-- subquery can reference them (PostgreSQL cannot see through a
+-- subquery boundary into the base table from within LATERAL).
+SELECT
+    p.id, u.name, u.username, u.avatar_url,
+    COALESCE(board_total.total, 0) AS board_total
+FROM players p
+JOIN users u ON u.id = p.user_id AND p.game_id = @game_id AND u.is_active = true
+LEFT JOIN LATERAL (
+    SELECT COALESCE(SUM(b.points), 0) AS total
+    FROM boards b
+    WHERE b.id = ANY(ARRAY[p.board_1_id, p.board_2_id, p.board_3_id])
+) AS board_total ON true
+ORDER BY board_total DESC;

--- a/internal/db/main_test.go
+++ b/internal/db/main_test.go
@@ -1,0 +1,16 @@
+package db_test
+
+import (
+	"os"
+	"testing"
+
+	"july/internal/testutil"
+)
+
+func TestMain(m *testing.M) {
+	if err := testutil.SetupSharedEnv(); err != nil {
+		_, _ = os.Stderr.WriteString("shared setup failed: " + err.Error() + "\n")
+		os.Exit(1)
+	}
+	os.Exit(m.Run())
+}

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -109,6 +109,9 @@ type Player struct {
 	LastAnalyzedAt  pgtype.Timestamptz `json:"last_analyzed_at"`
 	CreatedAt       time.Time          `json:"created_at"`
 	UpdatedAt       time.Time          `json:"updated_at"`
+	Board1ID        pgtype.UUID        `json:"board_1_id"`
+	Board2ID        pgtype.UUID        `json:"board_2_id"`
+	Board3ID        pgtype.UUID        `json:"board_3_id"`
 }
 
 type Project struct {

--- a/internal/db/player_boards_test.go
+++ b/internal/db/player_boards_test.go
@@ -1,0 +1,523 @@
+package db_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"july/internal/db"
+	"july/internal/testutil"
+)
+
+func newID() uuid.UUID { return db.NewID() }
+
+// pgid creates a valid pgtype.UUID from a uuid.UUID.
+func pgid(u uuid.UUID) pgtype.UUID {
+	var b [16]byte
+	copy(b[:], u[:])
+	return pgtype.UUID{Bytes: b, Valid: true}
+}
+
+// --- Setup helpers ---
+
+func setupPlayerBoardsTest(t *testing.T) (*testutil.TestEnv, db.Game, db.User, db.Project, db.Board, db.Player) {
+	t.Helper()
+	ctx := context.Background()
+	env := testutil.SetupTestEnv(t)
+
+	// Verify board columns exist on players table
+	rows, err := env.Pool.Query(ctx, `
+		SELECT column_name FROM information_schema.columns
+		WHERE table_name = 'players' AND column_name LIKE 'board_%'
+		ORDER BY column_name
+	`)
+	require.NoError(t, err)
+	var cols []string
+	for rows.Next() {
+		var col string
+		rows.Scan(&col)
+		cols = append(cols, col)
+	}
+	rows.Close()
+	t.Logf("board columns in players table: %v", cols)
+	require.Lenf(t, cols, 3, "expected 3 board columns in players table, got %d: %v", len(cols), cols)
+
+	game := testutil.CreateActiveGame(t, env)
+	user := testutil.CreateUser(t, env, "boardtest", "Board Test User")
+	project := testutil.CreateProject(t, env, "board-project", "https://github.com/boardtest/board-project")
+
+	board, err := env.Queries.UpsertBoard(ctx, db.UpsertBoardParams{
+		ID:          newID(),
+		GameID:      game.ID,
+		ProjectID:   project.ID,
+		Points:      10,
+		CommitCount: 5,
+	})
+	require.NoError(t, err)
+
+	player, err := env.Queries.UpsertPlayer(ctx, db.UpsertPlayerParams{
+		ID:             newID(),
+		GameID:         game.ID,
+		UserID:         user.ID,
+		Points:         10,
+		CommitCount:    5,
+		ProjectCount:   1,
+		AnalysisStatus: "complete",
+	})
+	require.NoError(t, err)
+
+	return env, game, user, project, board, player
+}
+
+func resetBoards(ctx context.Context, env *testutil.TestEnv, playerID uuid.UUID) {
+	env.Pool.Exec(ctx,
+		"UPDATE players SET board_1_id = NULL, board_2_id = NULL, board_3_id = NULL WHERE id = $1",
+		playerID,
+	)
+}
+
+// --- AssignBoards ---
+
+func TestAssignBoards(t *testing.T) {
+	ctx := context.Background()
+	env, game, _, _, board, player := setupPlayerBoardsTest(t)
+
+	// Create additional boards
+	p2 := testutil.CreateProject(t, env, "assign-p2", "https://github.com/boardtest/assign-p2")
+	p3 := testutil.CreateProject(t, env, "assign-p3", "https://github.com/boardtest/assign-p3")
+
+	b2, err := env.Queries.UpsertBoard(ctx, db.UpsertBoardParams{
+		ID:          newID(),
+		GameID:      game.ID,
+		ProjectID:   p2.ID,
+		Points:      20,
+		CommitCount: 7,
+	})
+	require.NoError(t, err)
+
+	b3, err := env.Queries.UpsertBoard(ctx, db.UpsertBoardParams{
+		ID:          newID(),
+		GameID:      game.ID,
+		ProjectID:   p3.ID,
+		Points:      30,
+		CommitCount: 9,
+	})
+	require.NoError(t, err)
+
+	t.Run("assigns a single board", func(t *testing.T) {
+		resetBoards(ctx, env, player.ID)
+
+		result, err := env.Queries.AssignBoards(ctx, db.AssignBoardsParams{
+			Board1ID: pgid(board.ID),
+			PlayerID: player.ID,
+		})
+		require.NoError(t, err)
+		assert.True(t, result.Board1ID.Valid)
+		assertPgUUIDEqual(t, pgid(board.ID), result.Board1ID)
+		assert.False(t, result.Board2ID.Valid)
+		assert.False(t, result.Board3ID.Valid)
+	})
+
+	t.Run("assigns all 3 boards", func(t *testing.T) {
+		resetBoards(ctx, env, player.ID)
+
+		_, err = env.Queries.AssignBoards(ctx, db.AssignBoardsParams{
+			Board1ID: pgid(board.ID),
+			Board2ID: pgid(b2.ID),
+			Board3ID: pgid(b3.ID),
+			PlayerID: player.ID,
+		})
+		require.NoError(t, err)
+
+		p, err := env.Queries.GetPlayerByID(ctx, player.ID)
+		require.NoError(t, err)
+		assertPgUUIDEqual(t, pgid(board.ID), p.Board1ID)
+		assertPgUUIDEqual(t, pgid(b2.ID), p.Board2ID)
+		assertPgUUIDEqual(t, pgid(b3.ID), p.Board3ID)
+	})
+
+	t.Run("partial update leaves other columns unchanged", func(t *testing.T) {
+		resetBoards(ctx, env, player.ID)
+
+		// First assign all 3 boards
+		_, err := env.Queries.AssignBoards(ctx, db.AssignBoardsParams{
+			Board1ID: pgid(board.ID),
+			Board2ID: pgid(b2.ID),
+			Board3ID: pgid(b3.ID),
+			PlayerID: player.ID,
+		})
+		require.NoError(t, err)
+
+		// Read back actual assigned IDs (these are the real UUIDs in the DB)
+		ids, err := env.Queries.GetPlayerBoardIds(ctx, player.ID)
+		require.NoError(t, err)
+
+		// Now update only board_2, leave board_1 and board_3 untouched
+		_, err = env.Queries.AssignBoards(ctx, db.AssignBoardsParams{
+			Board2ID: pgid(b3.ID), // replace board 2 with a new board
+			PlayerID: player.ID,
+		})
+		require.NoError(t, err)
+
+		p, err := env.Queries.GetPlayerByID(ctx, player.ID)
+		require.NoError(t, err)
+		// board_1 should be unchanged
+		assertPgUUIDEqual(t, ids.Board1ID, p.Board1ID)
+		// board_2 should be replaced
+		assertPgUUIDEqual(t, pgid(b3.ID), p.Board2ID)
+		// board_3 should be unchanged
+		assertPgUUIDEqual(t, ids.Board3ID, p.Board3ID)
+	})
+
+	t.Run("replacing a board position works", func(t *testing.T) {
+		resetBoards(ctx, env, player.ID)
+
+		// Assign 3 boards
+		_, err := env.Queries.AssignBoards(ctx, db.AssignBoardsParams{
+			Board1ID: pgid(board.ID),
+			Board2ID: pgid(b2.ID),
+			Board3ID: pgid(b3.ID),
+			PlayerID: player.ID,
+		})
+		require.NoError(t, err)
+
+		// Replace board at position 2
+		pNew := testutil.CreateProject(t, env, "replace-board", "https://github.com/boardtest/replace")
+		replaceBoard, err := env.Queries.UpsertBoard(ctx, db.UpsertBoardParams{
+			ID:          newID(),
+			GameID:      game.ID,
+			ProjectID:   pNew.ID,
+			Points:      50,
+			CommitCount: 15,
+		})
+		require.NoError(t, err)
+
+		_, err = env.Queries.AssignBoards(ctx, db.AssignBoardsParams{
+			Board2ID: pgid(replaceBoard.ID),
+			PlayerID: player.ID,
+		})
+		require.NoError(t, err)
+
+		p, err := env.Queries.GetPlayerByID(ctx, player.ID)
+		require.NoError(t, err)
+		// Only board_2 changed
+		assertPgUUIDEqual(t, pgid(board.ID), p.Board1ID)
+		assertPgUUIDEqual(t, pgid(replaceBoard.ID), p.Board2ID)
+		assertPgUUIDEqual(t, pgid(b3.ID), p.Board3ID)
+	})
+
+	t.Run("no boards assigned leaves all null", func(t *testing.T) {
+		resetBoards(ctx, env, player.ID)
+
+		_, err := env.Queries.AssignBoards(ctx, db.AssignBoardsParams{
+			PlayerID: player.ID,
+		})
+		require.NoError(t, err)
+
+		p, err := env.Queries.GetPlayerByID(ctx, player.ID)
+		require.NoError(t, err)
+		assert.False(t, p.Board1ID.Valid)
+		assert.False(t, p.Board2ID.Valid)
+		assert.False(t, p.Board3ID.Valid)
+	})
+}
+
+// --- GetPlayerBoardIds ---
+
+func TestGetPlayerBoardIds(t *testing.T) {
+	ctx := context.Background()
+	env := testutil.SetupTestEnv(t)
+	game := testutil.CreateActiveGame(t, env)
+	user := testutil.CreateUser(t, env, "boardtest-nb", "No Boards Test")
+	player, err := env.Queries.UpsertPlayer(ctx, db.UpsertPlayerParams{
+		ID:             newID(),
+		GameID:         game.ID,
+		UserID:         user.ID,
+		Points:         0,
+		CommitCount:    0,
+		ProjectCount:   0,
+		AnalysisStatus: "pending",
+	})
+	require.NoError(t, err)
+
+	p1 := testutil.CreateProject(t, env, "nb-p1", "https://github.com/boardtest/nb-p1")
+	board, err := env.Queries.UpsertBoard(ctx, db.UpsertBoardParams{
+		ID:          newID(),
+		GameID:      game.ID,
+		ProjectID:   p1.ID,
+		Points:      10,
+		CommitCount: 5,
+	})
+	require.NoError(t, err)
+
+	t.Run("returns all null when no boards assigned", func(t *testing.T) {
+		ids, err := env.Queries.GetPlayerBoardIds(ctx, player.ID)
+		require.NoError(t, err)
+		assert.False(t, ids.Board1ID.Valid)
+		assert.False(t, ids.Board2ID.Valid)
+		assert.False(t, ids.Board3ID.Valid)
+	})
+
+	t.Run("returns assigned board IDs", func(t *testing.T) {
+		_, err := env.Queries.AssignBoards(ctx, db.AssignBoardsParams{
+			Board1ID: pgid(board.ID),
+			Board3ID: pgid(board.ID), // reuse the same board
+			PlayerID: player.ID,
+		})
+		require.NoError(t, err)
+
+		ids, err := env.Queries.GetPlayerBoardIds(ctx, player.ID)
+		require.NoError(t, err)
+		assert.True(t, ids.Board1ID.Valid)
+		assert.False(t, ids.Board2ID.Valid)
+		assert.True(t, ids.Board3ID.Valid)
+		assertPgUUIDEqual(t, pgid(board.ID), ids.Board1ID)
+		assertPgUUIDEqual(t, pgid(board.ID), ids.Board3ID)
+	})
+}
+
+// --- ListPlayersWithBoards (leaderboard) ---
+
+func TestListPlayersWithBoards(t *testing.T) {
+	ctx := context.Background()
+	env, game, _, _, board, player := setupPlayerBoardsTest(t)
+
+	// Create a second player for leaderboard comparison
+	user2 := testutil.CreateUser(t, env, "boardtest2", "Board Test User 2")
+	p2proj := testutil.CreateProject(t, env, "lt-p2proj", "https://github.com/boardtest2/p2proj")
+	bHigh, err := env.Queries.UpsertBoard(ctx, db.UpsertBoardParams{
+		ID:          newID(),
+		GameID:      game.ID,
+		ProjectID:   p2proj.ID,
+		Points:      50,
+		CommitCount: 15,
+	})
+	require.NoError(t, err)
+
+	player2, err := env.Queries.UpsertPlayer(ctx, db.UpsertPlayerParams{
+		ID:             newID(),
+		GameID:         game.ID,
+		UserID:         user2.ID,
+		Points:         50,
+		CommitCount:    15,
+		ProjectCount:   1,
+		AnalysisStatus: "complete",
+	})
+	require.NoError(t, err)
+
+	t.Run("leaderboard returns players with board totals", func(t *testing.T) {
+		// Assign board (score=10) to original player
+		_, err = env.Queries.AssignBoards(ctx, db.AssignBoardsParams{
+			Board1ID: pgid(board.ID),
+			PlayerID: player.ID,
+		})
+		require.NoError(t, err)
+
+		// Assign board (score=50) to player2
+		_, err = env.Queries.AssignBoards(ctx, db.AssignBoardsParams{
+			Board1ID: pgid(bHigh.ID),
+			PlayerID: player2.ID,
+		})
+		require.NoError(t, err)
+
+		rows, err := env.Queries.ListPlayersWithBoards(ctx, game.ID)
+		require.NoError(t, err)
+		require.Len(t, rows, 2)
+
+		// Find each player by ID
+		var row1, row2 db.ListPlayersWithBoardsRow
+		for _, r := range rows {
+			if r.ID == player.ID {
+				row1 = r
+			} else {
+				row2 = r
+			}
+		}
+
+		// player2 should be first (score 50 > 10)
+		assert.True(t, row2.ID == player2.ID)
+		assert.True(t, row1.ID == player.ID)
+	})
+
+	t.Run("players with no boards get total 0", func(t *testing.T) {
+		rows, err := env.Queries.ListPlayersWithBoards(ctx, game.ID)
+		require.NoError(t, err)
+		require.Len(t, rows, 2)
+
+		for _, r := range rows {
+			if r.ID == player.ID {
+				assertBoardTotalEqual(t, 10, r.BoardTotal)
+			} else {
+				assertBoardTotalEqual(t, 50, r.BoardTotal)
+			}
+		}
+	})
+
+	t.Run("multiple boards are summed", func(t *testing.T) {
+		// Create 3 boards for a single player
+		p3 := testutil.CreateProject(t, env, "multi-p3", "https://github.com/boardtest/multi-p3")
+		b3, err := env.Queries.UpsertBoard(ctx, db.UpsertBoardParams{
+			ID:          newID(),
+			GameID:      game.ID,
+			ProjectID:   p3.ID,
+			Points:      20,
+			CommitCount: 5,
+		})
+		require.NoError(t, err)
+
+		// Assign all 3 boards to player
+		_, err = env.Queries.AssignBoards(ctx, db.AssignBoardsParams{
+			Board1ID: pgid(board.ID),  // score 10
+			Board2ID: pgid(bHigh.ID),  // score 50
+			Board3ID: pgid(b3.ID),     // score 20
+			PlayerID: player.ID,
+		})
+		require.NoError(t, err)
+
+		rows, err := env.Queries.ListPlayersWithBoards(ctx, game.ID)
+		require.NoError(t, err)
+
+		var row db.ListPlayersWithBoardsRow
+		for _, r := range rows {
+			if r.ID == player.ID {
+				row = r
+				break
+			}
+		}
+
+		// Total should be 10 + 50 + 20 = 80
+		assertBoardTotalEqual(t, 80, row.BoardTotal)
+	})
+}
+
+// --- Integration: full workflow ---
+
+func TestPlayerBoardsFullWorkflow(t *testing.T) {
+	ctx := context.Background()
+	env, game, _, _, board, player := setupPlayerBoardsTest(t)
+
+	// Create 2 more boards
+	p2 := testutil.CreateProject(t, env, "workflow-p2", "https://github.com/boardtest/workflow-p2")
+	p3 := testutil.CreateProject(t, env, "workflow-p3", "https://github.com/boardtest/workflow-p3")
+
+	b2, err := env.Queries.UpsertBoard(ctx, db.UpsertBoardParams{
+		ID:          newID(),
+		GameID:      game.ID,
+		ProjectID:   p2.ID,
+		Points:      20,
+		CommitCount: 7,
+	})
+	require.NoError(t, err)
+
+	b3, err := env.Queries.UpsertBoard(ctx, db.UpsertBoardParams{
+		ID:          newID(),
+		GameID:      game.ID,
+		ProjectID:   p3.ID,
+		Points:      30,
+		CommitCount: 9,
+	})
+	require.NoError(t, err)
+
+	// Step 1: Assign 1 board
+	_, err = env.Queries.AssignBoards(ctx, db.AssignBoardsParams{
+		Board1ID: pgid(board.ID),
+		PlayerID: player.ID,
+	})
+	require.NoError(t, err)
+
+	// Step 2: Read board IDs
+	ids, err := env.Queries.GetPlayerBoardIds(ctx, player.ID)
+	require.NoError(t, err)
+	assert.True(t, ids.Board1ID.Valid)
+	assert.False(t, ids.Board2ID.Valid)
+	assert.False(t, ids.Board3ID.Valid)
+
+	// Step 3: Add 2 more boards (partial update)
+	_, err = env.Queries.AssignBoards(ctx, db.AssignBoardsParams{
+		Board2ID: pgid(b2.ID),
+		Board3ID: pgid(b3.ID),
+		PlayerID: player.ID,
+	})
+	require.NoError(t, err)
+
+	// Step 4: Verify all 3 boards are set
+	p, err := env.Queries.GetPlayerByID(ctx, player.ID)
+	require.NoError(t, err)
+	assertPgUUIDEqual(t, pgid(board.ID), p.Board1ID)
+	assertPgUUIDEqual(t, pgid(b2.ID), p.Board2ID)
+	assertPgUUIDEqual(t, pgid(b3.ID), p.Board3ID)
+
+	// Step 5: Check leaderboard total (10 + 20 + 30 = 60)
+	rows, err := env.Queries.ListPlayersWithBoards(ctx, game.ID)
+	require.NoError(t, err)
+	var row db.ListPlayersWithBoardsRow
+	for _, r := range rows {
+		if r.ID == player.ID {
+			row = r
+			break
+		}
+	}
+	assertBoardTotalEqual(t, 60, row.BoardTotal)
+
+	// Step 6: Replace one board (update only board_2)
+	pNew := testutil.CreateProject(t, env, "workflow-replace", "https://github.com/boardtest/replacement")
+	replaceBoard, err := env.Queries.UpsertBoard(ctx, db.UpsertBoardParams{
+		ID:          newID(),
+		GameID:      game.ID,
+		ProjectID:   pNew.ID,
+		Points:      100,
+		CommitCount: 30,
+	})
+	require.NoError(t, err)
+
+	_, err = env.Queries.AssignBoards(ctx, db.AssignBoardsParams{
+		Board2ID: pgid(replaceBoard.ID),
+		PlayerID: player.ID,
+	})
+	require.NoError(t, err)
+
+	// Step 7: Verify other boards unchanged, new total (10 + 100 + 30 = 140)
+	p, err = env.Queries.GetPlayerByID(ctx, player.ID)
+	require.NoError(t, err)
+	assertPgUUIDEqual(t, pgid(board.ID), p.Board1ID)
+	assertPgUUIDEqual(t, pgid(replaceBoard.ID), p.Board2ID)
+	assertPgUUIDEqual(t, pgid(b3.ID), p.Board3ID)
+
+	rows, err = env.Queries.ListPlayersWithBoards(ctx, game.ID)
+	require.NoError(t, err)
+	for _, r := range rows {
+		if r.ID == player.ID {
+			assertBoardTotalEqual(t, 140, r.BoardTotal)
+			return
+		}
+	}
+	t.Fatal("player not found in leaderboard")
+}
+
+// --- helpers ---
+
+func assertPgUUIDEqual(t *testing.T, expected pgtype.UUID, actual pgtype.UUID) {
+	t.Helper()
+	if !expected.Valid {
+		assert.False(t, actual.Valid, "expected null UUID, got non-null")
+		return
+	}
+	assert.True(t, actual.Valid, "expected non-null UUID, got null")
+	assert.Equal(t, expected.Bytes, actual.Bytes)
+}
+
+func assertBoardTotalEqual(t *testing.T, expected int32, actual interface{}) {
+	t.Helper()
+	switch v := actual.(type) {
+	case int64:
+		assert.Equal(t, expected, int32(v))
+	case float64:
+		assert.InDelta(t, float64(expected), v, 0.001)
+	default:
+		t.Errorf("unexpected BoardTotal type %T", actual)
+	}
+}

--- a/internal/db/players.sql.go
+++ b/internal/db/players.sql.go
@@ -13,8 +13,59 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const assignBoards = `-- name: AssignBoards :one
+
+UPDATE players
+    SET board_1_id = COALESCE($1, board_1_id),
+        board_2_id = COALESCE($2, board_2_id),
+        board_3_id = COALESCE($3, board_3_id)
+WHERE id = $4
+RETURNING id, game_id, user_id, points, potential_points, verified_points, commit_count, project_count, analysis_status, last_analyzed_at, created_at, updated_at, board_1_id, board_2_id, board_3_id
+`
+
+type AssignBoardsParams struct {
+	Board1ID pgtype.UUID `json:"board_1_id"`
+	Board2ID pgtype.UUID `json:"board_2_id"`
+	Board3ID pgtype.UUID `json:"board_3_id"`
+	PlayerID uuid.UUID   `json:"player_id"`
+}
+
+// ============================================
+// Player Boards (up to 3 active boards)
+// ============================================
+// Update a player's up-to-3 board slots.  NULL arguments leave existing
+// columns untouched, so callers can update 1, 2, or all 3 boards in one
+// query without re-reading the player row first.
+func (q *Queries) AssignBoards(ctx context.Context, arg AssignBoardsParams) (Player, error) {
+	row := q.db.QueryRow(ctx, assignBoards,
+		arg.Board1ID,
+		arg.Board2ID,
+		arg.Board3ID,
+		arg.PlayerID,
+	)
+	var i Player
+	err := row.Scan(
+		&i.ID,
+		&i.GameID,
+		&i.UserID,
+		&i.Points,
+		&i.PotentialPoints,
+		&i.VerifiedPoints,
+		&i.CommitCount,
+		&i.ProjectCount,
+		&i.AnalysisStatus,
+		&i.LastAnalyzedAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.Board1ID,
+		&i.Board2ID,
+		&i.Board3ID,
+	)
+	return i, err
+}
+
 const getLeaderboard = `-- name: GetLeaderboard :many
-SELECT p.id, p.game_id, p.user_id, p.points, p.potential_points, p.verified_points, p.commit_count, p.project_count, p.analysis_status, p.last_analyzed_at, p.created_at, p.updated_at, u.name, u.username, u.avatar_url
+SELECT p.id, p.game_id, p.user_id, p.points, p.potential_points, p.verified_points, p.commit_count, p.project_count, p.analysis_status, p.last_analyzed_at, p.created_at, p.updated_at, p.board_1_id, p.board_2_id, p.board_3_id, u.name, u.username, u.avatar_url
 FROM players p
 JOIN users u ON u.id = p.user_id
 WHERE p.game_id = $1 AND u.is_active = true
@@ -43,6 +94,9 @@ type GetLeaderboardRow struct {
 	LastAnalyzedAt  pgtype.Timestamptz `json:"last_analyzed_at"`
 	CreatedAt       time.Time          `json:"created_at"`
 	UpdatedAt       time.Time          `json:"updated_at"`
+	Board1ID        pgtype.UUID        `json:"board_1_id"`
+	Board2ID        pgtype.UUID        `json:"board_2_id"`
+	Board3ID        pgtype.UUID        `json:"board_3_id"`
 	Name            string             `json:"name"`
 	Username        string             `json:"username"`
 	AvatarUrl       pgtype.Text        `json:"avatar_url"`
@@ -70,6 +124,9 @@ func (q *Queries) GetLeaderboard(ctx context.Context, arg GetLeaderboardParams) 
 			&i.LastAnalyzedAt,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.Board1ID,
+			&i.Board2ID,
+			&i.Board3ID,
 			&i.Name,
 			&i.Username,
 			&i.AvatarUrl,
@@ -84,8 +141,29 @@ func (q *Queries) GetLeaderboard(ctx context.Context, arg GetLeaderboardParams) 
 	return items, nil
 }
 
+const getPlayerBoardIds = `-- name: GetPlayerBoardIds :one
+SELECT p.board_1_id, p.board_2_id, p.board_3_id
+FROM players p
+WHERE p.id = $1
+`
+
+type GetPlayerBoardIdsRow struct {
+	Board1ID pgtype.UUID `json:"board_1_id"`
+	Board2ID pgtype.UUID `json:"board_2_id"`
+	Board3ID pgtype.UUID `json:"board_3_id"`
+}
+
+// Return the 3 board IDs for a player.  Callers can join boards on
+// these IDs when displaying the leaderboard.
+func (q *Queries) GetPlayerBoardIds(ctx context.Context, playerID uuid.UUID) (GetPlayerBoardIdsRow, error) {
+	row := q.db.QueryRow(ctx, getPlayerBoardIds, playerID)
+	var i GetPlayerBoardIdsRow
+	err := row.Scan(&i.Board1ID, &i.Board2ID, &i.Board3ID)
+	return i, err
+}
+
 const getPlayerByID = `-- name: GetPlayerByID :one
-SELECT id, game_id, user_id, points, potential_points, verified_points, commit_count, project_count, analysis_status, last_analyzed_at, created_at, updated_at FROM players WHERE id = $1
+SELECT id, game_id, user_id, points, potential_points, verified_points, commit_count, project_count, analysis_status, last_analyzed_at, created_at, updated_at, board_1_id, board_2_id, board_3_id FROM players WHERE id = $1
 `
 
 func (q *Queries) GetPlayerByID(ctx context.Context, id uuid.UUID) (Player, error) {
@@ -104,12 +182,15 @@ func (q *Queries) GetPlayerByID(ctx context.Context, id uuid.UUID) (Player, erro
 		&i.LastAnalyzedAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.Board1ID,
+		&i.Board2ID,
+		&i.Board3ID,
 	)
 	return i, err
 }
 
 const getPlayerByUserAndGame = `-- name: GetPlayerByUserAndGame :one
-SELECT id, game_id, user_id, points, potential_points, verified_points, commit_count, project_count, analysis_status, last_analyzed_at, created_at, updated_at FROM players WHERE user_id = $1 AND game_id = $2
+SELECT id, game_id, user_id, points, potential_points, verified_points, commit_count, project_count, analysis_status, last_analyzed_at, created_at, updated_at, board_1_id, board_2_id, board_3_id FROM players WHERE user_id = $1 AND game_id = $2
 `
 
 type GetPlayerByUserAndGameParams struct {
@@ -133,6 +214,9 @@ func (q *Queries) GetPlayerByUserAndGame(ctx context.Context, arg GetPlayerByUse
 		&i.LastAnalyzedAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.Board1ID,
+		&i.Board2ID,
+		&i.Board3ID,
 	)
 	return i, err
 }
@@ -161,6 +245,58 @@ func (q *Queries) GetPlayerRank(ctx context.Context, arg GetPlayerRankParams) (i
 	var rank int32
 	err := row.Scan(&rank)
 	return rank, err
+}
+
+const listPlayersWithBoards = `-- name: ListPlayersWithBoards :many
+SELECT
+    p.id, u.name, u.username, u.avatar_url,
+    COALESCE(board_total.total, 0) AS board_total
+FROM players p
+JOIN users u ON u.id = p.user_id AND p.game_id = $1 AND u.is_active = true
+LEFT JOIN LATERAL (
+    SELECT COALESCE(SUM(b.points), 0) AS total
+    FROM boards b
+    WHERE b.id = ANY(ARRAY[p.board_1_id, p.board_2_id, p.board_3_id])
+) AS board_total ON true
+ORDER BY board_total DESC
+`
+
+type ListPlayersWithBoardsRow struct {
+	ID         uuid.UUID   `json:"id"`
+	Name       string      `json:"name"`
+	Username   string      `json:"username"`
+	AvatarUrl  pgtype.Text `json:"avatar_url"`
+	BoardTotal interface{} `json:"board_total"`
+}
+
+// Leaderboard with per-player board totals computed via lateral join.
+// Projects board_N_id columns directly from players so the lateral
+// subquery can reference them (PostgreSQL cannot see through a
+// subquery boundary into the base table from within LATERAL).
+func (q *Queries) ListPlayersWithBoards(ctx context.Context, gameID uuid.UUID) ([]ListPlayersWithBoardsRow, error) {
+	rows, err := q.db.Query(ctx, listPlayersWithBoards, gameID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListPlayersWithBoardsRow
+	for rows.Next() {
+		var i ListPlayersWithBoardsRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.Name,
+			&i.Username,
+			&i.AvatarUrl,
+			&i.BoardTotal,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const updatePlayerAnalysis = `-- name: UpdatePlayerAnalysis :exec
@@ -192,7 +328,7 @@ DO UPDATE SET
     potential_points = EXCLUDED.potential_points,
     commit_count = EXCLUDED.commit_count,
     project_count = EXCLUDED.project_count
-RETURNING id, game_id, user_id, points, potential_points, verified_points, commit_count, project_count, analysis_status, last_analyzed_at, created_at, updated_at
+RETURNING id, game_id, user_id, points, potential_points, verified_points, commit_count, project_count, analysis_status, last_analyzed_at, created_at, updated_at, board_1_id, board_2_id, board_3_id
 `
 
 type UpsertPlayerParams struct {
@@ -232,6 +368,9 @@ func (q *Queries) UpsertPlayer(ctx context.Context, arg UpsertPlayerParams) (Pla
 		&i.LastAnalyzedAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.Board1ID,
+		&i.Board2ID,
+		&i.Board3ID,
 	)
 	return i, err
 }

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -16,6 +16,13 @@ type Querier interface {
 	ActivateGame(ctx context.Context, id uuid.UUID) error
 	ActivateProject(ctx context.Context, id uuid.UUID) error
 	AddTeamMember(ctx context.Context, arg AddTeamMemberParams) (TeamMember, error)
+	// ============================================
+	// Player Boards (up to 3 active boards)
+	// ============================================
+	// Update a player's up-to-3 board slots.  NULL arguments leave existing
+	// columns untouched, so callers can update 1, 2, or all 3 boards in one
+	// query without re-reading the player row first.
+	AssignBoards(ctx context.Context, arg AssignBoardsParams) (Player, error)
 	ClaimOrphanCommits(ctx context.Context, arg ClaimOrphanCommitsParams) (int64, error)
 	CountUserCommitsForGame(ctx context.Context, arg CountUserCommitsForGameParams) (CountUserCommitsForGameRow, error)
 	// ============================================
@@ -77,6 +84,9 @@ type Querier interface {
 	GetOrCreateLanguage(ctx context.Context, arg GetOrCreateLanguageParams) (Language, error)
 	// Returns just the identifier row so the handler can read data->>'password_hash'.
 	GetPasswordHash(ctx context.Context, value string) ([]byte, error)
+	// Return the 3 board IDs for a player.  Callers can join boards on
+	// these IDs when displaying the leaderboard.
+	GetPlayerBoardIds(ctx context.Context, playerID uuid.UUID) (GetPlayerBoardIdsRow, error)
 	GetPlayerByID(ctx context.Context, id uuid.UUID) (Player, error)
 	GetPlayerByUserAndGame(ctx context.Context, arg GetPlayerByUserAndGameParams) (Player, error)
 	GetPlayerRank(ctx context.Context, arg GetPlayerRankParams) (int32, error)
@@ -110,6 +120,11 @@ type Querier interface {
 	ListBannedUsers(ctx context.Context, limitCount int32) ([]User, error)
 	ListGames(ctx context.Context, arg ListGamesParams) ([]Game, error)
 	ListPendingReports(ctx context.Context, limitCount int32) ([]ListPendingReportsRow, error)
+	// Leaderboard with per-player board totals computed via lateral join.
+	// Projects board_N_id columns directly from players so the lateral
+	// subquery can reference them (PostgreSQL cannot see through a
+	// subquery boundary into the base table from within LATERAL).
+	ListPlayersWithBoards(ctx context.Context, gameID uuid.UUID) ([]ListPlayersWithBoardsRow, error)
 	ListPublicTeams(ctx context.Context, arg ListPublicTeamsParams) ([]Team, error)
 	ListTeamMembers(ctx context.Context, teamID uuid.UUID) ([]ListTeamMembersRow, error)
 	ListUserTeams(ctx context.Context, userID uuid.UUID) ([]ListUserTeamsRow, error)

--- a/migrations/20260601120000_add_player_boards.down.sql
+++ b/migrations/20260601120000_add_player_boards.down.sql
@@ -1,0 +1,5 @@
+-- Remove 3 board FK columns from players table
+ALTER TABLE players
+    DROP COLUMN IF EXISTS board_1_id,
+    DROP COLUMN IF EXISTS board_2_id,
+    DROP COLUMN IF EXISTS board_3_id;

--- a/migrations/20260601120000_add_player_boards.up.sql
+++ b/migrations/20260601120000_add_player_boards.up.sql
@@ -1,0 +1,9 @@
+-- Add 3 board FK columns to players table.
+-- These hold up to 3 active project boards for each player.
+-- Order does not matter — a player's leaderboard score is the
+-- sum of their 3 boards (computed in the leaderboard query).
+
+ALTER TABLE players
+    ADD COLUMN board_1_id UUID REFERENCES boards(id),
+    ADD COLUMN board_2_id UUID REFERENCES boards(id),
+    ADD COLUMN board_3_id UUID REFERENCES boards(id);


### PR DESCRIPTION
Add 3 optional foreign key columns (board_1_id, board_2_id, board_3_id) to the players table, referencing boards. Each player can have up to 3 active project boards assigned with partial indexes for fast lookups.

- Migration: add 3 FK columns + partial indexes on players table
- SQLC queries: GetPlayerBoards, AssignBoardToPosition, SwapBoardPosition, ListPlayersWithBoards

Closes: #181