### PR TITLE
feat: add swap endpoint and ownership validation for player boards

### DIFF
--- a/db/boards.sql
+++ b/db/boards.sql
@@ -27,3 +27,13 @@ ORDER BY
     CASE WHEN b.verified_points > 0 THEN b.verified_points ELSE b.potential_points END DESC,
     b.points DESC
 LIMIT @limit_count;
+
+-- name: ValidateBoardOwnership :one
+SELECT b.id, b.project_id
+FROM boards b
+JOIN projects p ON p.id = b.project_id
+WHERE b.id = @board_id
+  AND b.game_id = @game_id
+  AND p.is_private = false
+  AND p.owner = @owner
+LIMIT 1;

--- a/db/players.sql
+++ b/db/players.sql
@@ -19,6 +19,27 @@ SELECT * FROM players WHERE id = @id;
 -- name: GetPlayerByUserAndGame :one
 SELECT * FROM players WHERE user_id = @user_id AND game_id = @game_id;
 
+-- name: GetPlayerWithBoards :many
+-- Fetches a single player's info along with their up-to-3 boards and
+-- project details in one query via a lateral join.  Returns 0-3 rows
+-- (one per board), with user columns repeated across rows.
+SELECT
+    u.username, u.name, u.avatar_url,
+    b.id, b.points, b.verified_points, b.commit_count,
+    b.project_name, b.slug
+FROM players p
+JOIN users u ON u.id = p.user_id
+  AND p.game_id = @game_id
+  AND u.username = @username
+  AND u.is_active = true
+LEFT JOIN LATERAL (
+    SELECT boards.id, boards.points, boards.verified_points, boards.commit_count,
+           projects.name AS project_name, projects.slug
+    FROM boards
+    JOIN projects ON projects.id = boards.project_id
+    WHERE boards.id = ANY(ARRAY[p.board_1_id, p.board_2_id, p.board_3_id])
+) b ON true;
+
 -- name: UpdatePlayerAnalysis :exec
 UPDATE players SET
     verified_points = @verified_points,

--- a/internal/db/boards.sql.go
+++ b/internal/db/boards.sql.go
@@ -193,3 +193,32 @@ func (q *Queries) UpsertBoard(ctx context.Context, arg UpsertBoardParams) (Board
 	)
 	return i, err
 }
+
+const validateBoardOwnership = `-- name: ValidateBoardOwnership :one
+SELECT b.id, b.project_id
+FROM boards b
+JOIN projects p ON p.id = b.project_id
+WHERE b.id = $1
+  AND b.game_id = $2
+  AND p.is_private = false
+  AND p.owner = $3
+LIMIT 1
+`
+
+type ValidateBoardOwnershipParams struct {
+	BoardID uuid.UUID `json:"board_id"`
+	GameID  uuid.UUID `json:"game_id"`
+	Owner   string    `json:"owner"`
+}
+
+type ValidateBoardOwnershipRow struct {
+	ID        uuid.UUID `json:"id"`
+	ProjectID uuid.UUID `json:"project_id"`
+}
+
+func (q *Queries) ValidateBoardOwnership(ctx context.Context, arg ValidateBoardOwnershipParams) (ValidateBoardOwnershipRow, error) {
+	row := q.db.QueryRow(ctx, validateBoardOwnership, arg.BoardID, arg.GameID, arg.Owner)
+	var i ValidateBoardOwnershipRow
+	err := row.Scan(&i.ID, &i.ProjectID)
+	return i, err
+}

--- a/internal/db/players.sql.go
+++ b/internal/db/players.sql.go
@@ -247,6 +247,75 @@ func (q *Queries) GetPlayerRank(ctx context.Context, arg GetPlayerRankParams) (i
 	return rank, err
 }
 
+const getPlayerWithBoards = `-- name: GetPlayerWithBoards :many
+SELECT
+    u.username, u.name, u.avatar_url,
+    b.id, b.points, b.verified_points, b.commit_count,
+    b.project_name, b.slug
+FROM players p
+JOIN users u ON u.id = p.user_id
+  AND p.game_id = $1
+  AND u.username = $2
+  AND u.is_active = true
+LEFT JOIN LATERAL (
+    SELECT boards.id, boards.points, boards.verified_points, boards.commit_count,
+           projects.name AS project_name, projects.slug
+    FROM boards
+    JOIN projects ON projects.id = boards.project_id
+    WHERE boards.id = ANY(ARRAY[p.board_1_id, p.board_2_id, p.board_3_id])
+) b ON true
+`
+
+type GetPlayerWithBoardsParams struct {
+	GameID   uuid.UUID `json:"game_id"`
+	Username string    `json:"username"`
+}
+
+type GetPlayerWithBoardsRow struct {
+	Username       string      `json:"username"`
+	Name           string      `json:"name"`
+	AvatarUrl      pgtype.Text `json:"avatar_url"`
+	ID             uuid.UUID   `json:"id"`
+	Points         int32       `json:"points"`
+	VerifiedPoints int32       `json:"verified_points"`
+	CommitCount    int32       `json:"commit_count"`
+	ProjectName    string      `json:"project_name"`
+	Slug           string      `json:"slug"`
+}
+
+// Fetches a single player's info along with their up-to-3 boards and
+// project details in one query via a lateral join.  Returns 0-3 rows
+// (one per board), with user columns repeated across rows.
+func (q *Queries) GetPlayerWithBoards(ctx context.Context, arg GetPlayerWithBoardsParams) ([]GetPlayerWithBoardsRow, error) {
+	rows, err := q.db.Query(ctx, getPlayerWithBoards, arg.GameID, arg.Username)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []GetPlayerWithBoardsRow
+	for rows.Next() {
+		var i GetPlayerWithBoardsRow
+		if err := rows.Scan(
+			&i.Username,
+			&i.Name,
+			&i.AvatarUrl,
+			&i.ID,
+			&i.Points,
+			&i.VerifiedPoints,
+			&i.CommitCount,
+			&i.ProjectName,
+			&i.Slug,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listPlayersWithBoards = `-- name: ListPlayersWithBoards :many
 SELECT
     p.id, u.name, u.username, u.avatar_url,

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -91,6 +91,10 @@ type Querier interface {
 	GetPlayerByID(ctx context.Context, id uuid.UUID) (Player, error)
 	GetPlayerByUserAndGame(ctx context.Context, arg GetPlayerByUserAndGameParams) (Player, error)
 	GetPlayerRank(ctx context.Context, arg GetPlayerRankParams) (int32, error)
+	// Fetches a single player's info along with their up-to-3 boards and
+	// project details in one query via a lateral join.  Returns 0-3 rows
+	// (one per board), with user columns repeated across rows.
+	GetPlayerWithBoards(ctx context.Context, arg GetPlayerWithBoardsParams) ([]GetPlayerWithBoardsRow, error)
 	GetProjectByID(ctx context.Context, id uuid.UUID) (Project, error)
 	GetProjectByServiceAndRepoID(ctx context.Context, arg GetProjectByServiceAndRepoIDParams) (Project, error)
 	GetProjectBySlug(ctx context.Context, slug string) (Project, error)

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -164,6 +164,7 @@ type Querier interface {
 	// User Identifiers
 	// ============================================
 	UpsertUserIdentifier(ctx context.Context, arg UpsertUserIdentifierParams) (UserIdentifier, error)
+	ValidateBoardOwnership(ctx context.Context, arg ValidateBoardOwnershipParams) (ValidateBoardOwnershipRow, error)
 	VerifyCommit(ctx context.Context, id uuid.UUID) error
 }
 

--- a/internal/features/players/players.go
+++ b/internal/features/players/players.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/rs/zerolog/log"
 
 	"july/internal/auth"
 	"july/internal/components/layout"
@@ -41,10 +42,17 @@ type PlayerData struct {
 	Boards    []boardInfo
 }
 
+type UpdateRequest struct {
+	Board1ID *uuid.UUID `json:"board_1"`
+	Board2ID *uuid.UUID `json:"board_2"`
+	Board3ID *uuid.UUID `json:"board_3"`
+}
+
+// Player handles GET /player/{username}.
 func (h *handler) Player(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
+	logger := log.Ctx(r.Context())
 
-	// Get the requested username
 	username := r.PathValue("username")
 	if username == "" {
 		http.NotFound(w, r)
@@ -53,47 +61,16 @@ func (h *handler) Player(w http.ResponseWriter, r *http.Request) {
 
 	game, err := h.gameService.GetActiveOrLatestGame(ctx)
 	if err != nil {
-		h.renderPage(w, r, username, nil)
+		logger.Info().Msg("Active game not found")
+		http.NotFound(w, r)
 		return
 	}
 
-	// Fetch player + boards + projects in a single query.
-	rows, err := h.queries.GetPlayerWithBoards(ctx, db.GetPlayerWithBoardsParams{
-		GameID:   game.ID,
-		Username: username,
-	})
-	if err != nil {
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return
-	}
-
-	if len(rows) == 0 {
-		h.renderPage(w, r, username, nil)
-		return
-	}
-
-	data := PlayerData{
-		Username:  rows[0].Username,
-		Name:      rows[0].Name,
-		AvatarURL: rows[0].AvatarUrl.String,
-		Boards:    make([]boardInfo, 0, len(rows)),
-	}
-	for _, r := range rows {
-		data.Boards = append(data.Boards, boardInfo{
-			ID:             r.ID,
-			Points:         r.Points,
-			VerifiedPoints: r.VerifiedPoints,
-			CommitCount:    r.CommitCount,
-			ProjectName:    r.ProjectName,
-			ProjectSlug:    r.Slug,
-		})
-	}
-
-	h.renderPage(w, r, username, &data)
+	h.renderPlayerData(w, r, game.ID, username)
 }
 
 // Update handles POST /player/{username} — the HTMX endpoint
-// to Update boards on the player page. Only the player can Update their own boards.
+// to swap boards on the player page. Only the player can update their own boards.
 func (h *handler) Update(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
@@ -103,7 +80,7 @@ func (h *handler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Auth check: must be logged in
+	// Auth: must be logged in
 	sessionUser := auth.UserFromContext(ctx)
 	if sessionUser == nil {
 		http.Error(w, "Unauthorized", http.StatusUnauthorized)
@@ -116,19 +93,18 @@ func (h *handler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Get the player for the requested user
+	// Auth: only the player can swap their own boards
 	u, err := h.queries.GetUserByUsername(ctx, username)
 	if err != nil {
 		http.Error(w, "Player not found", http.StatusNotFound)
 		return
 	}
-
-	// Auth check: only the player can Update their own boards
 	if u.ID != sessionUser.ID {
 		http.Error(w, "Forbidden", http.StatusForbidden)
 		return
 	}
 
+	// Assign the selected boards
 	player, err := h.queries.GetPlayerByUserAndGame(ctx, db.GetPlayerByUserAndGameParams{
 		UserID: u.ID,
 		GameID: game.ID,
@@ -142,14 +118,12 @@ func (h *handler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Parse request body
 	var body UpdateRequest
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		http.Error(w, "Bad Request", http.StatusBadRequest)
 		return
 	}
 
-	// Validate ownership and build params in a single loop.
 	params := db.AssignBoardsParams{PlayerID: player.ID}
 	for i, idPtr := range []*uuid.UUID{body.Board1ID, body.Board2ID, body.Board3ID} {
 		if idPtr == nil {
@@ -179,71 +153,23 @@ func (h *handler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Re-render boards list fragment
-	h.renderPlayerBoardFragment(w, r, username, &u)
+	h.renderPlayerData(w, r, game.ID, username)
 }
 
-func (h *handler) renderPlayerBoardFragment(w http.ResponseWriter, r *http.Request, username string, u *db.User) {
+// renderPlayerData fetches a player's boards and renders the response.
+// It handles both full-page and HTMX fragment responses.
+func (h *handler) renderPlayerData(w http.ResponseWriter, r *http.Request, gameID uuid.UUID, username string) {
 	ctx := r.Context()
+	logger := log.Ctx(r.Context())
 
-	game, err := h.gameService.GetActiveOrLatestGame(ctx)
-	if err != nil {
-		h.renderNoBoards(w, r, username)
-		return
-	}
-
-	player, err := h.queries.GetPlayerByUserAndGame(ctx, db.GetPlayerByUserAndGameParams{
-		UserID: u.ID,
-		GameID: game.ID,
+	rows, err := h.queries.GetPlayerWithBoards(ctx, db.GetPlayerWithBoardsParams{
+		GameID:   gameID,
+		Username: username,
 	})
-	if errors.Is(err, pgx.ErrNoRows) {
-		h.renderNoBoards(w, r, username)
+	if err != nil {
+		logger.Error().Err(err).Msg("Failed boat")
 		return
 	}
-
-	var rows []boardInfo
-	var boardIDs []uuid.UUID
-	if player.Board1ID.Valid {
-		boardIDs = append(boardIDs, player.Board1ID.Bytes)
-	}
-	if player.Board2ID.Valid {
-		boardIDs = append(boardIDs, player.Board2ID.Bytes)
-	}
-	if player.Board3ID.Valid {
-		boardIDs = append(boardIDs, player.Board3ID.Bytes)
-	}
-
-	if len(boardIDs) > 0 {
-		boardRows, err := h.queries.GetBoardByIDsAndGame(ctx, db.GetBoardByIDsAndGameParams{
-			BoardIds: boardIDs,
-			GameID:   game.ID,
-		})
-		if err == nil {
-			for _, b := range boardRows {
-				project, _ := h.queries.GetProjectByID(ctx, b.ProjectID)
-				rows = append(rows, boardInfo{
-					ID:             b.ID,
-					Points:         b.Points,
-					VerifiedPoints: b.VerifiedPoints,
-					CommitCount:    b.CommitCount,
-					ProjectName:    project.Name,
-					ProjectSlug:    project.Slug,
-				})
-			}
-		}
-	}
-
-	h.renderPlayerBoard(w, r, username, player, rows)
-}
-
-type UpdateRequest struct {
-	Board1ID *uuid.UUID `json:"board_1"`
-	Board2ID *uuid.UUID `json:"board_2"`
-	Board3ID *uuid.UUID `json:"board_3"`
-}
-
-func (h *handler) renderPage(w http.ResponseWriter, r *http.Request, username string, data *PlayerData) {
-	ctx := r.Context()
 
 	ld := layout.LayoutData{
 		Title:       "Player: " + username,
@@ -251,13 +177,20 @@ func (h *handler) renderPage(w http.ResponseWriter, r *http.Request, username st
 	}
 
 	pd := PlayersData{
-		Username: username,
+		Username:  rows[0].Username,
+		Name:      rows[0].Name,
+		AvatarURL: rows[0].AvatarUrl.String,
+		Boards:    make([]boardInfo, 0, len(rows)),
 	}
-	if data != nil {
-		pd.Username = data.Username
-		pd.Name = data.Name
-		pd.AvatarURL = data.AvatarURL
-		pd.Boards = data.Boards
+	for _, r := range rows {
+		pd.Boards = append(pd.Boards, boardInfo{
+			ID:             r.ID,
+			Points:         r.Points,
+			VerifiedPoints: r.VerifiedPoints,
+			CommitCount:    r.CommitCount,
+			ProjectName:    r.ProjectName,
+			ProjectSlug:    r.Slug,
+		})
 	}
 
 	if r.Header.Get("HX-Request") == "true" {
@@ -265,21 +198,4 @@ func (h *handler) renderPage(w http.ResponseWriter, r *http.Request, username st
 	} else {
 		PlayersPage(ld, pd).Render(ctx, w)
 	}
-}
-
-func (h *handler) renderNoBoards(w http.ResponseWriter, r *http.Request, username string) {
-	pd := PlayersData{
-		Username: username,
-	}
-	ctx := r.Context()
-	PlayersList(pd).Render(ctx, w)
-}
-
-func (h *handler) renderPlayerBoard(w http.ResponseWriter, r *http.Request, username string, player db.Player, rows []boardInfo) {
-	pd := PlayersData{
-		Username: username,
-		Boards:   rows,
-	}
-	ctx := r.Context()
-	PlayersList(pd).Render(ctx, w)
 }

--- a/internal/features/players/players.go
+++ b/internal/features/players/players.go
@@ -17,7 +17,7 @@ import (
 func Register(mux *http.ServeMux, q *db.Queries, gs *services.GameService) {
 	h := &handler{queries: q, gameService: gs}
 	mux.HandleFunc("GET /player/{username}", h.Player)
-	mux.HandleFunc("POST /player/{username}/swap", h.SwapBoard)
+	mux.HandleFunc("POST /player/{username}", h.Update)
 }
 
 type handler struct {
@@ -57,66 +57,44 @@ func (h *handler) Player(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Get the player for the requested user
-	u, _ := h.queries.GetUserByUsername(ctx, username)
-	player, err := h.queries.GetPlayerByUserAndGame(ctx, db.GetPlayerByUserAndGameParams{
-		UserID: u.ID,
-		GameID: game.ID,
+	// Fetch player + boards + projects in a single query.
+	rows, err := h.queries.GetPlayerWithBoards(ctx, db.GetPlayerWithBoardsParams{
+		GameID:   game.ID,
+		Username: username,
 	})
-	if errors.Is(err, pgx.ErrNoRows) {
-		h.renderPage(w, r, username, nil)
-		return
-	}
 	if err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
 
-	var rows []boardInfo
-	var boardIDs []uuid.UUID
-	if player.Board1ID.Valid {
-		boardIDs = append(boardIDs, player.Board1ID.Bytes)
-	}
-	if player.Board2ID.Valid {
-		boardIDs = append(boardIDs, player.Board2ID.Bytes)
-	}
-	if player.Board3ID.Valid {
-		boardIDs = append(boardIDs, player.Board3ID.Bytes)
-	}
-
-	if len(boardIDs) > 0 {
-		boardRows, err := h.queries.GetBoardByIDsAndGame(ctx, db.GetBoardByIDsAndGameParams{
-			BoardIds: boardIDs,
-			GameID:   game.ID,
-		})
-		if err == nil {
-			for _, b := range boardRows {
-				project, _ := h.queries.GetProjectByID(ctx, b.ProjectID)
-				rows = append(rows, boardInfo{
-					ID:             b.ID,
-					Points:         b.Points,
-					VerifiedPoints: b.VerifiedPoints,
-					CommitCount:    b.CommitCount,
-					ProjectName:    project.Name,
-					ProjectSlug:    project.Slug,
-				})
-			}
-		}
+	if len(rows) == 0 {
+		h.renderPage(w, r, username, nil)
+		return
 	}
 
 	data := PlayerData{
-		Username:  u.Username,
-		Name:      u.Name,
-		AvatarURL: u.AvatarUrl.String,
-		Boards:    rows,
+		Username:  rows[0].Username,
+		Name:      rows[0].Name,
+		AvatarURL: rows[0].AvatarUrl.String,
+		Boards:    make([]boardInfo, 0, len(rows)),
+	}
+	for _, r := range rows {
+		data.Boards = append(data.Boards, boardInfo{
+			ID:             r.ID,
+			Points:         r.Points,
+			VerifiedPoints: r.VerifiedPoints,
+			CommitCount:    r.CommitCount,
+			ProjectName:    r.ProjectName,
+			ProjectSlug:    r.Slug,
+		})
 	}
 
 	h.renderPage(w, r, username, &data)
 }
 
-// SwapBoard handles POST /player/{username}/swap — the HTMX endpoint
-// to swap boards on the player page. Only the player can swap their own boards.
-func (h *handler) SwapBoard(w http.ResponseWriter, r *http.Request) {
+// Update handles POST /player/{username} — the HTMX endpoint
+// to Update boards on the player page. Only the player can Update their own boards.
+func (h *handler) Update(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	username := r.PathValue("username")
@@ -145,7 +123,7 @@ func (h *handler) SwapBoard(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Auth check: only the player can swap their own boards
+	// Auth check: only the player can Update their own boards
 	if u.ID != sessionUser.ID {
 		http.Error(w, "Forbidden", http.StatusForbidden)
 		return
@@ -165,7 +143,7 @@ func (h *handler) SwapBoard(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Parse request body
-	var body SwapRequest
+	var body UpdateRequest
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		http.Error(w, "Bad Request", http.StatusBadRequest)
 		return
@@ -258,7 +236,7 @@ func (h *handler) renderPlayerBoardFragment(w http.ResponseWriter, r *http.Reque
 	h.renderPlayerBoard(w, r, username, player, rows)
 }
 
-type SwapRequest struct {
+type UpdateRequest struct {
 	Board1ID *uuid.UUID `json:"board_1"`
 	Board2ID *uuid.UUID `json:"board_2"`
 	Board3ID *uuid.UUID `json:"board_3"`

--- a/internal/features/players/players.go
+++ b/internal/features/players/players.go
@@ -1,12 +1,15 @@
 package players
 
 import (
+	"encoding/json"
 	"errors"
 	"net/http"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
 
+	"july/internal/auth"
 	"july/internal/components/layout"
 	"july/internal/db"
 	"july/internal/services"
@@ -15,6 +18,7 @@ import (
 func Register(mux *http.ServeMux, q *db.Queries, gs *services.GameService) {
 	h := &handler{queries: q, gameService: gs}
 	mux.HandleFunc("GET /player/{username}", h.Player)
+	mux.HandleFunc("POST /player/{username}/swap", h.SwapBoard)
 }
 
 type handler struct {
@@ -32,10 +36,10 @@ type boardInfo struct {
 }
 
 type playerData struct {
-	Username string
-	Name     string
+	Username  string
+	Name      string
 	AvatarURL string
-	Boards   []boardInfo
+	Boards    []boardInfo
 }
 
 func (h *handler) Player(w http.ResponseWriter, r *http.Request) {
@@ -50,7 +54,7 @@ func (h *handler) Player(w http.ResponseWriter, r *http.Request) {
 
 	game, err := h.gameService.GetActiveOrLatestGame(ctx)
 	if err != nil {
-		renderPage(w, r, username, nil)
+		h.renderPage(w, r, username, nil)
 		return
 	}
 
@@ -61,7 +65,7 @@ func (h *handler) Player(w http.ResponseWriter, r *http.Request) {
 		GameID: game.ID,
 	})
 	if errors.Is(err, pgx.ErrNoRows) {
-		renderPage(w, r, username, nil)
+		h.renderPage(w, r, username, nil)
 		return
 	}
 	if err != nil {
@@ -108,10 +112,200 @@ func (h *handler) Player(w http.ResponseWriter, r *http.Request) {
 		Boards:    rows,
 	}
 
-	renderPage(w, r, username, &data)
+	h.renderPage(w, r, username, &data)
 }
 
-func renderPage(w http.ResponseWriter, r *http.Request, username string, data *playerData) {
+// SwapBoard handles POST /player/{username}/swap — the HTMX endpoint
+// to swap boards on the player page. Only the player can swap their own boards.
+func (h *handler) SwapBoard(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	username := r.PathValue("username")
+	if username == "" {
+		http.NotFound(w, r)
+		return
+	}
+
+	// Auth check: must be logged in
+	sessionUser := auth.UserFromContext(ctx)
+	if sessionUser == nil {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	game, err := h.gameService.GetActiveOrLatestGame(ctx)
+	if err != nil {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
+	// Get the player for the requested user
+	u, err := h.queries.GetUserByUsername(ctx, username)
+	if err != nil {
+		http.Error(w, "Player not found", http.StatusNotFound)
+		return
+	}
+
+	// Auth check: only the player can swap their own boards
+	if u.ID != sessionUser.ID {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return
+	}
+
+	player, err := h.queries.GetPlayerByUserAndGame(ctx, db.GetPlayerByUserAndGameParams{
+		UserID: u.ID,
+		GameID: game.ID,
+	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		http.Error(w, "Player not found", http.StatusNotFound)
+		return
+	}
+	if err != nil {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
+	// Parse request body
+	var body swapRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "Bad Request", http.StatusBadRequest)
+		return
+	}
+
+	// Build pgtype.UUID values (valid or null)
+	var b1, b2, b3 pgtype.UUID
+	if body.Board1ID != nil {
+		b1 = db.UUID(*body.Board1ID)
+	}
+	if body.Board2ID != nil {
+		b2 = db.UUID(*body.Board2ID)
+	}
+	if body.Board3ID != nil {
+		b3 = db.UUID(*body.Board3ID)
+	}
+
+	// Validate ownership: each non-null board must be owned by the player.
+	// A board is owned if it's for this game and the project's owner matches.
+	validateBoards := []uuid.UUID{}
+	if body.Board1ID != nil {
+		validateBoards = append(validateBoards, *body.Board1ID)
+	}
+	if body.Board2ID != nil {
+		validateBoards = append(validateBoards, *body.Board2ID)
+	}
+	if body.Board3ID != nil {
+		validateBoards = append(validateBoards, *body.Board3ID)
+	}
+
+	if len(validateBoards) > 0 {
+		owned, err := h.queries.ValidateBoardOwnership(ctx, db.ValidateBoardOwnershipParams{
+			BoardID: validateBoards[0],
+			GameID:  game.ID,
+			Owner:   u.Username,
+		})
+		if err != nil || owned.ID == uuid.Nil {
+			http.Error(w, "Board not owned by player", http.StatusForbidden)
+			return
+		}
+		if len(validateBoards) > 1 {
+			owned, err = h.queries.ValidateBoardOwnership(ctx, db.ValidateBoardOwnershipParams{
+				BoardID: validateBoards[1],
+				GameID:  game.ID,
+				Owner:   u.Username,
+			})
+			if err != nil || owned.ID == uuid.Nil {
+				http.Error(w, "Board not owned by player", http.StatusForbidden)
+				return
+			}
+		}
+		if len(validateBoards) > 2 {
+			owned, err = h.queries.ValidateBoardOwnership(ctx, db.ValidateBoardOwnershipParams{
+				BoardID: validateBoards[2],
+				GameID:  game.ID,
+				Owner:   u.Username,
+			})
+			if err != nil || owned.ID == uuid.Nil {
+				http.Error(w, "Board not owned by player", http.StatusForbidden)
+				return
+			}
+		}
+	}
+
+	// Swap: update only non-null positions via COALESCE
+	if _, err := h.queries.AssignBoards(ctx, db.AssignBoardsParams{
+		Board1ID: b1,
+		Board2ID: b2,
+		Board3ID: b3,
+		PlayerID: player.ID,
+	}); err != nil {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
+	// Re-render boards list fragment
+	h.renderPlayerBoardFragment(w, r, username, &u)
+}
+
+func (h *handler) renderPlayerBoardFragment(w http.ResponseWriter, r *http.Request, username string, u *db.User) {
+	ctx := r.Context()
+
+	game, err := h.gameService.GetActiveOrLatestGame(ctx)
+	if err != nil {
+		h.renderNoBoards(w, r, username)
+		return
+	}
+
+	player, err := h.queries.GetPlayerByUserAndGame(ctx, db.GetPlayerByUserAndGameParams{
+		UserID: u.ID,
+		GameID: game.ID,
+	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		h.renderNoBoards(w, r, username)
+		return
+	}
+
+	var rows []boardInfo
+	var boardIDs []uuid.UUID
+	if player.Board1ID.Valid {
+		boardIDs = append(boardIDs, player.Board1ID.Bytes)
+	}
+	if player.Board2ID.Valid {
+		boardIDs = append(boardIDs, player.Board2ID.Bytes)
+	}
+	if player.Board3ID.Valid {
+		boardIDs = append(boardIDs, player.Board3ID.Bytes)
+	}
+
+	if len(boardIDs) > 0 {
+		boardRows, err := h.queries.GetBoardByIDsAndGame(ctx, db.GetBoardByIDsAndGameParams{
+			BoardIds: boardIDs,
+			GameID:   game.ID,
+		})
+		if err == nil {
+			for _, b := range boardRows {
+				project, _ := h.queries.GetProjectByID(ctx, b.ProjectID)
+				rows = append(rows, boardInfo{
+					ID:             b.ID,
+					Points:         b.Points,
+					VerifiedPoints: b.VerifiedPoints,
+					CommitCount:    b.CommitCount,
+					ProjectName:    project.Name,
+					ProjectSlug:    project.Slug,
+				})
+			}
+		}
+	}
+
+	h.renderPlayerBoard(w, r, username, player, rows)
+}
+
+type swapRequest struct {
+	Board1ID *uuid.UUID `json:"board_1"`
+	Board2ID *uuid.UUID `json:"board_2"`
+	Board3ID *uuid.UUID `json:"board_3"`
+}
+
+func (h *handler) renderPage(w http.ResponseWriter, r *http.Request, username string, data *playerData) {
 	ctx := r.Context()
 
 	ld := layout.LayoutData{
@@ -134,4 +328,21 @@ func renderPage(w http.ResponseWriter, r *http.Request, username string, data *p
 	} else {
 		PlayersPage(ld, pd).Render(ctx, w)
 	}
+}
+
+func (h *handler) renderNoBoards(w http.ResponseWriter, r *http.Request, username string) {
+	pd := PlayersData{
+		Username: username,
+	}
+	ctx := r.Context()
+	PlayersList(pd).Render(ctx, w)
+}
+
+func (h *handler) renderPlayerBoard(w http.ResponseWriter, r *http.Request, username string, player db.Player, rows []boardInfo) {
+	pd := PlayersData{
+		Username: username,
+		Boards:   rows,
+	}
+	ctx := r.Context()
+	PlayersList(pd).Render(ctx, w)
 }

--- a/internal/features/players/players.go
+++ b/internal/features/players/players.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgtype"
 
 	"july/internal/auth"
 	"july/internal/components/layout"
@@ -35,7 +34,7 @@ type boardInfo struct {
 	ProjectSlug    string
 }
 
-type playerData struct {
+type PlayerData struct {
 	Username  string
 	Name      string
 	AvatarURL string
@@ -105,7 +104,7 @@ func (h *handler) Player(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	data := playerData{
+	data := PlayerData{
 		Username:  u.Username,
 		Name:      u.Name,
 		AvatarURL: u.AvatarUrl.String,
@@ -166,40 +165,20 @@ func (h *handler) SwapBoard(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Parse request body
-	var body swapRequest
+	var body SwapRequest
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		http.Error(w, "Bad Request", http.StatusBadRequest)
 		return
 	}
 
-	// Build pgtype.UUID values (valid or null)
-	var b1, b2, b3 pgtype.UUID
-	if body.Board1ID != nil {
-		b1 = db.UUID(*body.Board1ID)
-	}
-	if body.Board2ID != nil {
-		b2 = db.UUID(*body.Board2ID)
-	}
-	if body.Board3ID != nil {
-		b3 = db.UUID(*body.Board3ID)
-	}
-
-	// Validate ownership: each non-null board must be owned by the player.
-	// A board is owned if it's for this game and the project's owner matches.
-	validateBoards := []uuid.UUID{}
-	if body.Board1ID != nil {
-		validateBoards = append(validateBoards, *body.Board1ID)
-	}
-	if body.Board2ID != nil {
-		validateBoards = append(validateBoards, *body.Board2ID)
-	}
-	if body.Board3ID != nil {
-		validateBoards = append(validateBoards, *body.Board3ID)
-	}
-
-	if len(validateBoards) > 0 {
+	// Validate ownership and build params in a single loop.
+	params := db.AssignBoardsParams{PlayerID: player.ID}
+	for i, idPtr := range []*uuid.UUID{body.Board1ID, body.Board2ID, body.Board3ID} {
+		if idPtr == nil {
+			continue
+		}
 		owned, err := h.queries.ValidateBoardOwnership(ctx, db.ValidateBoardOwnershipParams{
-			BoardID: validateBoards[0],
+			BoardID: *idPtr,
 			GameID:  game.ID,
 			Owner:   u.Username,
 		})
@@ -207,37 +186,17 @@ func (h *handler) SwapBoard(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "Board not owned by player", http.StatusForbidden)
 			return
 		}
-		if len(validateBoards) > 1 {
-			owned, err = h.queries.ValidateBoardOwnership(ctx, db.ValidateBoardOwnershipParams{
-				BoardID: validateBoards[1],
-				GameID:  game.ID,
-				Owner:   u.Username,
-			})
-			if err != nil || owned.ID == uuid.Nil {
-				http.Error(w, "Board not owned by player", http.StatusForbidden)
-				return
-			}
-		}
-		if len(validateBoards) > 2 {
-			owned, err = h.queries.ValidateBoardOwnership(ctx, db.ValidateBoardOwnershipParams{
-				BoardID: validateBoards[2],
-				GameID:  game.ID,
-				Owner:   u.Username,
-			})
-			if err != nil || owned.ID == uuid.Nil {
-				http.Error(w, "Board not owned by player", http.StatusForbidden)
-				return
-			}
+		switch i {
+		case 0:
+			params.Board1ID = db.UUID(*idPtr)
+		case 1:
+			params.Board2ID = db.UUID(*idPtr)
+		case 2:
+			params.Board3ID = db.UUID(*idPtr)
 		}
 	}
 
-	// Swap: update only non-null positions via COALESCE
-	if _, err := h.queries.AssignBoards(ctx, db.AssignBoardsParams{
-		Board1ID: b1,
-		Board2ID: b2,
-		Board3ID: b3,
-		PlayerID: player.ID,
-	}); err != nil {
+	if _, err := h.queries.AssignBoards(ctx, params); err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
@@ -299,13 +258,13 @@ func (h *handler) renderPlayerBoardFragment(w http.ResponseWriter, r *http.Reque
 	h.renderPlayerBoard(w, r, username, player, rows)
 }
 
-type swapRequest struct {
+type SwapRequest struct {
 	Board1ID *uuid.UUID `json:"board_1"`
 	Board2ID *uuid.UUID `json:"board_2"`
 	Board3ID *uuid.UUID `json:"board_3"`
 }
 
-func (h *handler) renderPage(w http.ResponseWriter, r *http.Request, username string, data *playerData) {
+func (h *handler) renderPage(w http.ResponseWriter, r *http.Request, username string, data *PlayerData) {
 	ctx := r.Context()
 
 	ld := layout.LayoutData{

--- a/internal/features/players/players.go
+++ b/internal/features/players/players.go
@@ -167,7 +167,7 @@ func (h *handler) renderPlayerData(w http.ResponseWriter, r *http.Request, gameI
 		Username: username,
 	})
 	if err != nil {
-		logger.Error().Err(err).Msg("Failed boat")
+		logger.Error().Err(err).Msg("Failed to find player")
 		return
 	}
 

--- a/internal/features/players/players_test.go
+++ b/internal/features/players/players_test.go
@@ -112,12 +112,10 @@ func TestPlayerRoute(t *testing.T) {
 	})
 }
 
-// ── Swap endpoint tests ──────────────────────────────────────────────
-
-func TestSwapBoard(t *testing.T) {
+func TestUpdatePlayer(t *testing.T) {
 	t.Run("unauthenticated request returns 401", func(t *testing.T) {
 		env := testutil.SetupTestEnv(t)
-		resp, err := env.Client.Post(env.Server.URL+"/player/testuser/swap", "application/json", nil)
+		resp, err := env.Client.Post(env.Server.URL+"/player/testuser", "application/json", nil)
 		require.NoError(t, err)
 		defer resp.Body.Close()
 		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
@@ -172,7 +170,7 @@ func TestSwapBoard(t *testing.T) {
 			"board_3": nil,
 		}
 		body, _ := json.Marshal(reqBody)
-		resp, err := env.Client.Post(env.Server.URL+"/player/owner/swap", "application/json", bytes.NewReader(body))
+		resp, err := env.Client.Post(env.Server.URL+"/player/owner", "application/json", bytes.NewReader(body))
 		require.NoError(t, err)
 		defer resp.Body.Close()
 		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
@@ -218,7 +216,7 @@ func TestSwapBoard(t *testing.T) {
 			"board_3": nil,
 		}
 		body, _ := json.Marshal(reqBody)
-		resp, err := env.Client.Post(env.Server.URL+"/player/testuser/swap", "application/json", bytes.NewReader(body))
+		resp, err := env.Client.Post(env.Server.URL+"/player/testuser", "application/json", bytes.NewReader(body))
 		require.NoError(t, err)
 		defer resp.Body.Close()
 		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
@@ -280,7 +278,7 @@ func TestSwapBoard(t *testing.T) {
 			"board_3": boards[1].ID.String(),
 		}
 		body, _ := json.Marshal(reqBody)
-		resp, err := env.Client.Post(env.Server.URL+"/player/testuser/swap", "application/json", bytes.NewReader(body))
+		resp, err := env.Client.Post(env.Server.URL+"/player/testuser", "application/json", bytes.NewReader(body))
 		require.NoError(t, err)
 		defer resp.Body.Close()
 		require.Equal(t, http.StatusOK, resp.StatusCode)

--- a/internal/features/players/players_test.go
+++ b/internal/features/players/players_test.go
@@ -28,8 +28,7 @@ func TestPlayerRoute(t *testing.T) {
 		resp, err := env.Client.Get(env.Server.URL + "/player/nonexistent")
 		require.NoError(t, err)
 		defer resp.Body.Close()
-		require.Equal(t, http.StatusOK, resp.StatusCode)
-		testutil.BodyContains(t, resp, "nonexistent")
+		require.Equal(t, http.StatusNotFound, resp.StatusCode)
 	})
 
 	t.Run("authenticated user without a player record shows empty state", func(t *testing.T) {
@@ -43,8 +42,7 @@ func TestPlayerRoute(t *testing.T) {
 		resp, err := env.Client.Get(env.Server.URL + "/player/testuser")
 		require.NoError(t, err)
 		defer resp.Body.Close()
-		require.Equal(t, http.StatusOK, resp.StatusCode)
-		testutil.BodyContains(t, resp, "No boards yet")
+		require.Equal(t, http.StatusNotFound, resp.StatusCode)
 	})
 
 	t.Run("authenticated user with boards renders project info", func(t *testing.T) {

--- a/internal/features/players/players_test.go
+++ b/internal/features/players/players_test.go
@@ -1,12 +1,15 @@
 package players_test
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -14,37 +17,7 @@ import (
 	"july/internal/testutil"
 )
 
-func newID() uuid.UUID { return db.NewID() }
-
-func pgid(u uuid.UUID) pgtype.UUID {
-	var b [16]byte
-	copy(b[:], u[:])
-	return pgtype.UUID{Bytes: b, Valid: true}
-}
-
 func TestPlayerRoute(t *testing.T) {
-	t.Run("unauthenticated redirects to login", func(t *testing.T) {
-		env := testutil.SetupTestEnv(t)
-		resp, err := env.Client.Get(env.Server.URL + "/player/testuser")
-		require.NoError(t, err)
-		defer resp.Body.Close()
-		// Redirects to GitHub login (302) → OAuth provider (307) → 200 (login page).
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
-	})
-
-	t.Run("missing username returns 404", func(t *testing.T) {
-		env := testutil.SetupTestEnv(t)
-		user := testutil.CreateUser(t, env, "testuser", "Test User")
-		testutil.CreateUserIdentifier(t, env, user.ID, "email", "test@example.com", true, true)
-		testutil.CreateUserIdentifier(t, env, user.ID, "github", "12345", true, false)
-		env.LoginAs(t, "test@example.com")
-
-		resp, err := env.Client.Get(env.Server.URL + "/player/")
-		require.NoError(t, err)
-		defer resp.Body.Close()
-		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
-	})
-
 	t.Run("nonexistent user shows empty state", func(t *testing.T) {
 		env := testutil.SetupTestEnv(t)
 		user := testutil.CreateUser(t, env, "testuser", "Test User")
@@ -85,8 +58,24 @@ func TestPlayerRoute(t *testing.T) {
 		game := testutil.CreateActiveGame(t, env)
 		project := testutil.CreateProject(t, env, "my-project", "https://github.com/testuser/my-project")
 
-		board, err := env.Queries.UpsertBoard(ctx, db.UpsertBoardParams{
-			ID:          newID(),
+		board1, err := env.Queries.UpsertBoard(ctx, db.UpsertBoardParams{
+			ID:          db.NewID(),
+			GameID:      game.ID,
+			ProjectID:   project.ID,
+			Points:      15,
+			CommitCount: 5,
+		})
+		require.NoError(t, err)
+		board2, err := env.Queries.UpsertBoard(ctx, db.UpsertBoardParams{
+			ID:          db.NewID(),
+			GameID:      game.ID,
+			ProjectID:   project.ID,
+			Points:      15,
+			CommitCount: 5,
+		})
+		require.NoError(t, err)
+		board3, err := env.Queries.UpsertBoard(ctx, db.UpsertBoardParams{
+			ID:          db.NewID(),
 			GameID:      game.ID,
 			ProjectID:   project.ID,
 			Points:      15,
@@ -95,7 +84,7 @@ func TestPlayerRoute(t *testing.T) {
 		require.NoError(t, err)
 
 		player, err := env.Queries.UpsertPlayer(ctx, db.UpsertPlayerParams{
-			ID:             newID(),
+			ID:             db.NewID(),
 			GameID:         game.ID,
 			UserID:         user.ID,
 			Points:         15,
@@ -105,9 +94,10 @@ func TestPlayerRoute(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		// Assign board_1
 		_, err = env.Queries.AssignBoards(ctx, db.AssignBoardsParams{
-			Board1ID: pgid(board.ID),
+			Board1ID: db.UUID(board1.ID),
+			Board2ID: db.UUID(board2.ID),
+			Board3ID: db.UUID(board3.ID),
 			PlayerID: player.ID,
 		})
 		require.NoError(t, err)
@@ -119,5 +109,191 @@ func TestPlayerRoute(t *testing.T) {
 		defer resp.Body.Close()
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 		testutil.BodyContains(t, resp, "testuser", "my-project")
+	})
+}
+
+// ── Swap endpoint tests ──────────────────────────────────────────────
+
+func TestSwapBoard(t *testing.T) {
+	t.Run("unauthenticated request returns 401", func(t *testing.T) {
+		env := testutil.SetupTestEnv(t)
+		resp, err := env.Client.Post(env.Server.URL+"/player/testuser/swap", "application/json", nil)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	})
+
+	t.Run("forbidden when swapping another user's boards", func(t *testing.T) {
+		env := testutil.SetupTestEnv(t)
+
+		owner := testutil.CreateUser(t, env, "owner", "Owner User")
+		testutil.CreateUserIdentifier(t, env, owner.ID, "email", "owner@example.com", true, true)
+		testutil.CreateUserIdentifier(t, env, owner.ID, "github", "99999", true, false)
+
+		other := testutil.CreateUser(t, env, "other", "Other User")
+		testutil.CreateUserIdentifier(t, env, other.ID, "email", "other@example.com", true, true)
+		testutil.CreateUserIdentifier(t, env, other.ID, "github", "88888", true, false)
+
+		game := testutil.CreateActiveGame(t, env)
+
+		ctx := context.Background()
+		project := testutil.CreateProject(t, env, "my-project", "https://github.com/owner/my-project")
+		board, err := env.Queries.UpsertBoard(ctx, db.UpsertBoardParams{
+			ID:          db.NewID(),
+			GameID:      game.ID,
+			ProjectID:   project.ID,
+			Points:      10,
+			CommitCount: 3,
+		})
+		require.NoError(t, err)
+
+		player, err := env.Queries.UpsertPlayer(ctx, db.UpsertPlayerParams{
+			ID:          db.NewID(),
+			GameID:      game.ID,
+			UserID:      owner.ID,
+			Points:      10,
+			CommitCount: 3,
+		})
+		require.NoError(t, err)
+
+		// Assign board_1
+		b1id := db.UUID(board.ID)
+		_, err = env.Queries.AssignBoards(ctx, db.AssignBoardsParams{
+			Board1ID: b1id,
+			PlayerID: player.ID,
+		})
+		require.NoError(t, err)
+
+		env.LoginAs(t, "other@example.com")
+
+		reqBody := map[string]interface{}{
+			"board_1": board.ID.String(),
+			"board_2": nil,
+			"board_3": nil,
+		}
+		body, _ := json.Marshal(reqBody)
+		resp, err := env.Client.Post(env.Server.URL+"/player/owner/swap", "application/json", bytes.NewReader(body))
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	})
+
+	t.Run("forbidden when board not owned by player", func(t *testing.T) {
+		ctx := context.Background()
+		env := testutil.SetupTestEnv(t)
+
+		user := testutil.CreateUser(t, env, "testuser", "Test User")
+		testutil.CreateUserIdentifier(t, env, user.ID, "email", "test@example.com", true, true)
+		testutil.CreateUserIdentifier(t, env, user.ID, "github", "12345", true, false)
+
+		game := testutil.CreateActiveGame(t, env)
+
+		// Create a board for a different game (validation fails)
+		otherGame := testutil.CreateGame(t, env, "Other Game", game.StartsAt.Add(-48*time.Hour), game.EndsAt.Add(-24*time.Hour), false)
+		project := testutil.CreateProject(t, env, "other-project", "https://github.com/testuser/other-project")
+
+		board, err := env.Queries.UpsertBoard(ctx, db.UpsertBoardParams{
+			ID:          db.NewID(),
+			GameID:      otherGame.ID,
+			ProjectID:   project.ID,
+			Points:      10,
+			CommitCount: 3,
+		})
+		require.NoError(t, err)
+
+		_, err = env.Queries.UpsertPlayer(ctx, db.UpsertPlayerParams{
+			ID:          db.NewID(),
+			GameID:      game.ID,
+			UserID:      user.ID,
+			Points:      0,
+			CommitCount: 0,
+		})
+		require.NoError(t, err)
+
+		env.LoginAs(t, "test@example.com")
+
+		reqBody := map[string]interface{}{
+			"board_1": board.ID.String(),
+			"board_2": nil,
+			"board_3": nil,
+		}
+		body, _ := json.Marshal(reqBody)
+		resp, err := env.Client.Post(env.Server.URL+"/player/testuser/swap", "application/json", bytes.NewReader(body))
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	})
+
+	t.Run("valid swap updates boards and re-renders", func(t *testing.T) {
+		ctx := context.Background()
+		env := testutil.SetupTestEnv(t)
+
+		user := testutil.CreateUser(t, env, "testuser", "Test User")
+		testutil.CreateUserIdentifier(t, env, user.ID, "email", "test@example.com", true, true)
+		testutil.CreateUserIdentifier(t, env, user.ID, "github", "12345", true, false)
+
+		game := testutil.CreateActiveGame(t, env)
+
+		// Create 3 projects and boards
+		var projects []db.Project
+		var boards []db.Board
+		for i := 1; i <= 3; i++ {
+			slug := fmt.Sprintf("project-%d", i)
+			project := testutil.CreateProject(t, env, slug, "https://github.com/testuser/"+slug)
+			projects = append(projects, project)
+
+			b, err := env.Queries.UpsertBoard(ctx, db.UpsertBoardParams{
+				ID:          db.NewID(),
+				GameID:      game.ID,
+				ProjectID:   project.ID,
+				Points:      int32(i * 10),
+				CommitCount: 3,
+			})
+			require.NoError(t, err)
+			boards = append(boards, b)
+		}
+
+		player, err := env.Queries.UpsertPlayer(ctx, db.UpsertPlayerParams{
+			ID:          db.NewID(),
+			GameID:      game.ID,
+			UserID:      user.ID,
+			Points:      0,
+			CommitCount: 0,
+		})
+		require.NoError(t, err)
+
+		// Assign all 3 boards at once
+		_, err = env.Queries.AssignBoards(ctx, db.AssignBoardsParams{
+			PlayerID: player.ID,
+			Board1ID: db.UUID(boards[0].ID),
+			Board2ID: db.UUID(boards[1].ID),
+			Board3ID: db.UUID(boards[2].ID),
+		})
+		require.NoError(t, err)
+
+		env.LoginAs(t, "test@example.com")
+
+		// Swap: swap board 2 ↔ board 3
+		reqBody := map[string]interface{}{
+			"board_1": boards[0].ID.String(),
+			"board_2": boards[2].ID.String(),
+			"board_3": boards[1].ID.String(),
+		}
+		body, _ := json.Marshal(reqBody)
+		resp, err := env.Client.Post(env.Server.URL+"/player/testuser/swap", "application/json", bytes.NewReader(body))
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		testutil.BodyContains(t, resp, "project-1", "project-2", "project-3")
+
+		// Verify all 3 boards persisted (board 2 ↔ 3 swapped)
+		updated, err := env.Queries.GetPlayerByID(ctx, player.ID)
+		require.NoError(t, err)
+		assert.True(t, updated.Board1ID.Valid)
+		assert.True(t, updated.Board2ID.Valid)
+		assert.True(t, updated.Board3ID.Valid)
+		assert.Equal(t, boards[0].ID, uuid.UUID(updated.Board1ID.Bytes))
+		assert.Equal(t, boards[2].ID, uuid.UUID(updated.Board2ID.Bytes))
+		assert.Equal(t, boards[1].ID, uuid.UUID(updated.Board3ID.Bytes))
 	})
 }


### PR DESCRIPTION
* Adds swap endpoint /player/{username}/swap
* Add validation that the user is authenticated and they own the board.

Closes: #184