### PR TITLE
test: Add score reset tests

### DIFF
--- a/internal/db/boards.sql.go
+++ b/internal/db/boards.sql.go
@@ -145,6 +145,36 @@ func (q *Queries) GetProjectLeaderboard(ctx context.Context, arg GetProjectLeade
 	return items, nil
 }
 
+const updateBoardVerifiedPoints = `-- name: UpdateBoardVerifiedPoints :one
+UPDATE boards
+SET verified_points = $1
+WHERE id = $2
+RETURNING id, game_id, project_id, points, potential_points, verified_points, commit_count, contributor_count, created_at, updated_at
+`
+
+type UpdateBoardVerifiedPointsParams struct {
+	VerifiedPoints int32     `json:"verified_points"`
+	BoardID        uuid.UUID `json:"board_id"`
+}
+
+func (q *Queries) UpdateBoardVerifiedPoints(ctx context.Context, arg UpdateBoardVerifiedPointsParams) (Board, error) {
+	row := q.db.QueryRow(ctx, updateBoardVerifiedPoints, arg.VerifiedPoints, arg.BoardID)
+	var i Board
+	err := row.Scan(
+		&i.ID,
+		&i.GameID,
+		&i.ProjectID,
+		&i.Points,
+		&i.PotentialPoints,
+		&i.VerifiedPoints,
+		&i.CommitCount,
+		&i.ContributorCount,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
 const upsertBoard = `-- name: UpsertBoard :one
 
 INSERT INTO boards (id, game_id, project_id, points, potential_points, commit_count, contributor_count)

--- a/internal/db/commits.sql.go
+++ b/internal/db/commits.sql.go
@@ -123,6 +123,59 @@ func (q *Queries) CreateCommit(ctx context.Context, arg CreateCommitParams) (Com
 	return i, err
 }
 
+const createCommitSimple = `-- name: CreateCommitSimple :one
+INSERT INTO commits (id, hash, project_id, author, email, message, url, timestamp)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+RETURNING id, hash, project_id, user_id, game_id, author, email, message, url, timestamp, languages, files, is_verified, is_flagged, flag_reason, created_at, updated_at
+`
+
+type CreateCommitSimpleParams struct {
+	ID        uuid.UUID   `json:"id"`
+	Hash      pgtype.Text `json:"hash"`
+	ProjectID uuid.UUID   `json:"project_id"`
+	Author    pgtype.Text `json:"author"`
+	Email     pgtype.Text `json:"email"`
+	Message   string      `json:"message"`
+	Url       string      `json:"url"`
+	Timestamp time.Time   `json:"timestamp"`
+}
+
+// Inserts a commit without user_id/game_id/languages/files.
+// Primarily used for tests that need precise control over commit creation.
+func (q *Queries) CreateCommitSimple(ctx context.Context, arg CreateCommitSimpleParams) (Commit, error) {
+	row := q.db.QueryRow(ctx, createCommitSimple,
+		arg.ID,
+		arg.Hash,
+		arg.ProjectID,
+		arg.Author,
+		arg.Email,
+		arg.Message,
+		arg.Url,
+		arg.Timestamp,
+	)
+	var i Commit
+	err := row.Scan(
+		&i.ID,
+		&i.Hash,
+		&i.ProjectID,
+		&i.UserID,
+		&i.GameID,
+		&i.Author,
+		&i.Email,
+		&i.Message,
+		&i.Url,
+		&i.Timestamp,
+		&i.Languages,
+		&i.Files,
+		&i.IsVerified,
+		&i.IsFlagged,
+		&i.FlagReason,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
 const flagCommit = `-- name: FlagCommit :exec
 UPDATE commits SET
     is_flagged = true,

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -33,6 +33,9 @@ type Querier interface {
 	// Commits
 	// ============================================
 	CreateCommit(ctx context.Context, arg CreateCommitParams) (Commit, error)
+	// Inserts a commit without user_id/game_id/languages/files.
+	// Primarily used for tests that need precise control over commit creation.
+	CreateCommitSimple(ctx context.Context, arg CreateCommitSimpleParams) (Commit, error)
 	// ============================================
 	// Games
 	// ============================================
@@ -147,6 +150,7 @@ type Querier interface {
 	// Called after AI grading for L2/L3 upgrades only.
 	// Requires the metric to already be at L1 (enforced in the handler).
 	UpdateAnalysisMetricLevel(ctx context.Context, arg UpdateAnalysisMetricLevelParams) error
+	UpdateBoardVerifiedPoints(ctx context.Context, arg UpdateBoardVerifiedPointsParams) (Board, error)
 	UpdatePlayerAnalysis(ctx context.Context, arg UpdatePlayerAnalysisParams) error
 	UpdateProjectService(ctx context.Context, arg UpdateProjectServiceParams) (Project, error)
 	UpdateTeam(ctx context.Context, arg UpdateTeamParams) error

--- a/internal/db/queries/boards.sql
+++ b/internal/db/queries/boards.sql
@@ -12,6 +12,12 @@ DO UPDATE SET
     commit_count = boards.commit_count + EXCLUDED.commit_count
 RETURNING *;
 
+-- name: UpdateBoardVerifiedPoints :one
+UPDATE boards
+SET verified_points = @verified_points
+WHERE id = @board_id
+RETURNING *;
+
 -- name: GetBoardByIDsAndGame :many
 SELECT * FROM boards WHERE id = ANY(@board_ids::uuid[]) AND game_id = @game_id;
 

--- a/internal/db/queries/commits.sql
+++ b/internal/db/queries/commits.sql
@@ -8,6 +8,13 @@ VALUES (@id, @hash, @project_id, @user_id, @game_id, @author, @email, @message, 
 ON CONFLICT (hash) DO NOTHING
 RETURNING *;
 
+-- name: CreateCommitSimple :one
+-- Inserts a commit without user_id/game_id/languages/files.
+-- Primarily used for tests that need precise control over commit creation.
+INSERT INTO commits (id, hash, project_id, author, email, message, url, timestamp)
+VALUES (@id, @hash, @project_id, @author, @email, @message, @url, @timestamp)
+RETURNING *;
+
 -- name: GetCommitByHash :one
 SELECT * FROM commits WHERE hash = @hash;
 

--- a/internal/services/game_test.go
+++ b/internal/services/game_test.go
@@ -2,6 +2,7 @@ package services_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -404,4 +405,205 @@ func TestGameService_AddCommit_BoardGapFill(t *testing.T) {
 	require.True(t, ids.Board2ID.Valid, "board_2 should be valid")
 	assert.Equal(t, expectedBytes, ids.Board2ID.Bytes, "board_2 should remain unchanged")
 	assert.False(t, ids.Board3ID.Valid, "board_3 should not be assigned yet")
+}
+
+// TestGameService_ScoreReset verifies that scoring is isolated per game:
+// - New game Board rows start with points = 0 (no carryover from old games)
+// - Existing boards.verified_points from prior games are NOT affected
+// - Total score displays correctly: total = boards.points + boards.verified_points
+func TestGameService_ScoreReset(t *testing.T) {
+	env := testutil.SetupTestEnv(t)
+	svc := services.NewGameService(env.Queries)
+	ctx := context.Background()
+
+	t.Run("new game Board rows start with points = 0, no carryover from old games", func(t *testing.T) {
+		// Create game 1 with a project, then add commits to build up points
+		game1 := testutil.CreateActiveGame(t, env)
+		project1 := testutil.CreateProject(t, env, "scoregame1-proj",
+			"https://github.com/scoreuser1/scoregame1-proj")
+
+		// Insert 3 commits directly (same pattern as TestGameService_AddCommit)
+		for i := 0; i < 3; i++ {
+			commitID := uuid.New()
+			_, err := env.Pool.Exec(ctx,
+				"INSERT INTO commits (id, hash, project_id, author, email, message, url, timestamp) "+
+					"VALUES ($1, $2, $3, 'Score User 1', 'scoreuser1@test.com', 'Commit 1', 'http://test', now())",
+				commitID, fmt.Sprintf("game1-commit-%d", i), project1.ID)
+			require.NoError(t, err)
+
+			commit, err := env.Queries.GetCommitByHashStr(ctx, fmt.Sprintf("game1-commit-%d", i))
+			require.NoError(t, err)
+			err = svc.AddCommit(ctx, commit)
+			require.NoError(t, err)
+		}
+
+		// Verify game 1 board has points from 3 commits
+		board1, err := env.Queries.GetBoardByProjectAndGame(ctx, db.GetBoardByProjectAndGameParams{
+			ProjectID: project1.ID,
+			GameID:    game1.ID,
+		})
+		require.NoError(t, err)
+		assert.Greater(t, board1.Points, int32(0), "game 1 board should have points > 0 (3 commits + 1 project)")
+
+		// Deactivate game 1 and create a new game
+		err = env.Queries.DeactivateGame(ctx, game1.ID)
+		require.NoError(t, err)
+		game2 := testutil.CreateActiveGame(t, env)
+
+		// Insert a single commit into the same project but game 2
+		commitID2 := uuid.New()
+		_, err = env.Pool.Exec(ctx,
+			"INSERT INTO commits (id, hash, project_id, author, email, message, url, timestamp) "+
+				"VALUES ($1, $2, $3, 'Score User 1', 'scoreuser1@test.com', 'Commit 2', 'http://test', now())",
+			commitID2, "game2-commit-0", project1.ID)
+		require.NoError(t, err)
+
+		commit2, err := env.Queries.GetCommitByHashStr(ctx, "game2-commit-0")
+		require.NoError(t, err)
+		err = svc.AddCommit(ctx, commit2)
+		require.NoError(t, err)
+
+		// Verify game 2's board for the same project has only 1 commit's worth of points
+		board2, err := env.Queries.GetBoardByProjectAndGame(ctx, db.GetBoardByProjectAndGameParams{
+			ProjectID: project1.ID,
+			GameID:    game2.ID,
+		})
+		require.NoError(t, err)
+		// 1 commit (1) + 1 project (10) = 11
+		assert.Equal(t, int32(11), board2.Points, "game 2 board should have 11 points (fresh start, 1 commit + 1 project)")
+
+		// Verify game 1's board was NOT affected by game 2's commit
+		board1After, err := env.Queries.GetBoardByProjectAndGame(ctx, db.GetBoardByProjectAndGameParams{
+			ProjectID: project1.ID,
+			GameID:    game1.ID,
+		})
+		require.NoError(t, err)
+		assert.Greater(t, board1After.Points, int32(0), "game 1 board should still have points > 0 (unchanged)")
+	})
+
+	t.Run("boards.verified_points from prior games on the same project are NOT affected", func(t *testing.T) {
+		// Create game 1 with a project that has a board with verified_points set
+		game1 := testutil.CreateActiveGame(t, env)
+		project1 := testutil.CreateProject(t, env, "verifiedgame1-proj",
+			"https://github.com/verifieduser1/verifiedgame1-proj")
+
+		// Add a commit through game 1
+		commitID := uuid.New()
+		_, err := env.Pool.Exec(ctx,
+			"INSERT INTO commits (id, hash, project_id, author, email, message, url, timestamp) "+
+				"VALUES ($1, $2, $3, 'Verified User 1', 'verifieduser1@test.com', 'Commit 1', 'http://test', now())",
+			commitID, "verified1-commit-0", project1.ID)
+		require.NoError(t, err)
+
+		commit1, err := env.Queries.GetCommitByHashStr(ctx, "verified1-commit-0")
+		require.NoError(t, err)
+		err = svc.AddCommit(ctx, commit1)
+		require.NoError(t, err)
+
+		// Get the game 1 board (verified_points defaults to 0)
+		board1, err := env.Queries.GetBoardByProjectAndGame(ctx, db.GetBoardByProjectAndGameParams{
+			ProjectID: project1.ID,
+			GameID:    game1.ID,
+		})
+		require.NoError(t, err)
+		assert.Greater(t, board1.Points, int32(0)) // from 1 commit + 1 project
+		assert.Equal(t, int32(0), board1.VerifiedPoints) // default
+
+		// Set verified_points = 15 to simulate AI analysis.
+		// UpsertBoard does NOT update verified_points (it's not in the SQL),
+		// so direct SQL is the only way to set it — same pattern as TestGameService_AddCommit.
+		_, err = env.Pool.Exec(ctx,
+			"UPDATE boards SET verified_points = 15 WHERE id = $1", board1.ID)
+		require.NoError(t, err)
+
+		// Verify game 1 board now has verified_points = 15
+		board1WithVerified, err := env.Queries.GetBoardByProjectAndGame(ctx, db.GetBoardByProjectAndGameParams{
+			ProjectID: project1.ID,
+			GameID:    game1.ID,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, int32(15), board1WithVerified.VerifiedPoints)
+
+		// Deactivate game 1 and create game 2
+		err = env.Queries.DeactivateGame(ctx, game1.ID)
+		require.NoError(t, err)
+		game2 := testutil.CreateActiveGame(t, env)
+
+		// Add a commit through game 2 (same project)
+		commitID2 := uuid.New()
+		_, err = env.Pool.Exec(ctx,
+			"INSERT INTO commits (id, hash, project_id, author, email, message, url, timestamp) "+
+				"VALUES ($1, $2, $3, 'Verified User 1', 'verifieduser1@test.com', 'Commit 2', 'http://test', now())",
+			commitID2, "verified2-commit-0", project1.ID)
+		require.NoError(t, err)
+
+		commit2, err := env.Queries.GetCommitByHashStr(ctx, "verified2-commit-0")
+		require.NoError(t, err)
+		err = svc.AddCommit(ctx, commit2)
+		require.NoError(t, err)
+
+		// Verify game 2's board has verified_points = 0 (default, no AI analysis)
+		board2, err := env.Queries.GetBoardByProjectAndGame(ctx, db.GetBoardByProjectAndGameParams{
+			ProjectID: project1.ID,
+			GameID:    game2.ID,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, int32(0), board2.VerifiedPoints, "game 2 board should have verified_points = 0 (no AI set)")
+
+		// Verify game 1's board verified_points is STILL 15 (unchanged by game 2 operations)
+		board1After, err := env.Queries.GetBoardByProjectAndGame(ctx, db.GetBoardByProjectAndGameParams{
+			ProjectID: project1.ID,
+			GameID:    game1.ID,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, int32(15), board1After.VerifiedPoints, "game 1 board verified_points must not be affected by game 2")
+	})
+
+	t.Run("total score: total = boards.points + boards.verified_points", func(t *testing.T) {
+		game := testutil.CreateActiveGame(t, env)
+		project := testutil.CreateProject(t, env, "totalgame-proj",
+			"https://github.com/totaluser/totalgame-proj")
+
+		// Add 2 commits through game 1
+		for i := 0; i < 2; i++ {
+			commitID := uuid.New()
+			_, err := env.Pool.Exec(ctx,
+				"INSERT INTO commits (id, hash, project_id, author, email, message, url, timestamp) "+
+					"VALUES ($1, $2, $3, 'Total User', 'totaluser@test.com', 'Commit %d', 'http://test', now())",
+				commitID, fmt.Sprintf("total-commit-%d", i), project.ID)
+			require.NoError(t, err)
+
+			commit, err := env.Queries.GetCommitByHashStr(ctx, fmt.Sprintf("total-commit-%d", i))
+			require.NoError(t, err)
+			err = svc.AddCommit(ctx, commit)
+			require.NoError(t, err)
+		}
+
+		// Get the board
+		board, err := env.Queries.GetBoardByProjectAndGame(ctx, db.GetBoardByProjectAndGameParams{
+			ProjectID: project.ID,
+			GameID:    game.ID,
+		})
+		require.NoError(t, err)
+
+		// board.points = 2 commits * 1 + 1 project * 10 = 12
+		assert.Equal(t, int32(12), board.Points,
+			"board.points should be 12 (2 commits * 1 + 1 project * 10)")
+		assert.Equal(t, int32(0), board.VerifiedPoints)
+
+		// Simulate AI analysis by manually setting verified_points = 5
+		_, err = env.Pool.Exec(ctx,
+			"UPDATE boards SET verified_points = 5 WHERE id = $1", board.ID)
+		require.NoError(t, err)
+
+		// Verify the computed total: 12 + 5 = 17
+		boardAfter, err := env.Queries.GetBoardByProjectAndGame(ctx, db.GetBoardByProjectAndGameParams{
+			ProjectID: project.ID,
+			GameID:    game.ID,
+		})
+		require.NoError(t, err)
+		expectedTotal := boardAfter.Points + boardAfter.VerifiedPoints
+		assert.Equal(t, int32(17), expectedTotal,
+			"total should be 17 (points 12 + verified_points 5)")
+	})
 }

--- a/internal/services/game_test.go
+++ b/internal/services/game_test.go
@@ -422,16 +422,22 @@ func TestGameService_ScoreReset(t *testing.T) {
 		project1 := testutil.CreateProject(t, env, "scoregame1-proj",
 			"https://github.com/scoreuser1/scoregame1-proj")
 
-		// Insert 3 commits directly (same pattern as TestGameService_AddCommit)
+		// Insert 3 commits via SQLC query (same pattern as TestGameService_AddCommit)
 		for i := 0; i < 3; i++ {
-			commitID := uuid.New()
-			_, err := env.Pool.Exec(ctx,
-				"INSERT INTO commits (id, hash, project_id, author, email, message, url, timestamp) "+
-					"VALUES ($1, $2, $3, 'Score User 1', 'scoreuser1@test.com', 'Commit 1', 'http://test', now())",
-				commitID, fmt.Sprintf("game1-commit-%d", i), project1.ID)
+			commitHash := fmt.Sprintf("game1-commit-%d", i)
+			_, err := env.Queries.CreateCommitSimple(ctx, db.CreateCommitSimpleParams{
+				ID:        db.NewID(),
+				Hash:      db.Text(commitHash),
+				ProjectID: project1.ID,
+				Author:    db.Text("Score User 1"),
+				Email:     db.Text("scoreuser1@test.com"),
+				Message:   "Commit 1",
+				Url:       "http://test",
+				Timestamp: time.Now(),
+			})
 			require.NoError(t, err)
 
-			commit, err := env.Queries.GetCommitByHashStr(ctx, fmt.Sprintf("game1-commit-%d", i))
+			commit, err := env.Queries.GetCommitByHashStr(ctx, commitHash)
 			require.NoError(t, err)
 			err = svc.AddCommit(ctx, commit)
 			require.NoError(t, err)
@@ -450,12 +456,17 @@ func TestGameService_ScoreReset(t *testing.T) {
 		require.NoError(t, err)
 		game2 := testutil.CreateActiveGame(t, env)
 
-		// Insert a single commit into the same project but game 2
-		commitID2 := uuid.New()
-		_, err = env.Pool.Exec(ctx,
-			"INSERT INTO commits (id, hash, project_id, author, email, message, url, timestamp) "+
-				"VALUES ($1, $2, $3, 'Score User 1', 'scoreuser1@test.com', 'Commit 2', 'http://test', now())",
-			commitID2, "game2-commit-0", project1.ID)
+		// Insert a single commit via SQLC into the same project but game 2
+		_, err = env.Queries.CreateCommitSimple(ctx, db.CreateCommitSimpleParams{
+			ID:        db.NewID(),
+			Hash:      db.Text("game2-commit-0"),
+			ProjectID: project1.ID,
+			Author:    db.Text("Score User 1"),
+			Email:     db.Text("scoreuser1@test.com"),
+			Message:   "Commit 2",
+			Url:       "http://test",
+			Timestamp: time.Now(),
+		})
 		require.NoError(t, err)
 
 		commit2, err := env.Queries.GetCommitByHashStr(ctx, "game2-commit-0")
@@ -487,12 +498,17 @@ func TestGameService_ScoreReset(t *testing.T) {
 		project1 := testutil.CreateProject(t, env, "verifiedgame1-proj",
 			"https://github.com/verifieduser1/verifiedgame1-proj")
 
-		// Add a commit through game 1
-		commitID := uuid.New()
-		_, err := env.Pool.Exec(ctx,
-			"INSERT INTO commits (id, hash, project_id, author, email, message, url, timestamp) "+
-				"VALUES ($1, $2, $3, 'Verified User 1', 'verifieduser1@test.com', 'Commit 1', 'http://test', now())",
-			commitID, "verified1-commit-0", project1.ID)
+		// Add a commit via SQLC
+		_, err := env.Queries.CreateCommitSimple(ctx, db.CreateCommitSimpleParams{
+			ID:        db.NewID(),
+			Hash:      db.Text("verified1-commit-0"),
+			ProjectID: project1.ID,
+			Author:    db.Text("Verified User 1"),
+			Email:     db.Text("verifieduser1@test.com"),
+			Message:   "Commit 1",
+			Url:       "http://test",
+			Timestamp: time.Now(),
+		})
 		require.NoError(t, err)
 
 		commit1, err := env.Queries.GetCommitByHashStr(ctx, "verified1-commit-0")
@@ -509,11 +525,13 @@ func TestGameService_ScoreReset(t *testing.T) {
 		assert.Greater(t, board1.Points, int32(0)) // from 1 commit + 1 project
 		assert.Equal(t, int32(0), board1.VerifiedPoints) // default
 
-		// Set verified_points = 15 to simulate AI analysis.
+		// Set verified_points = 15 to simulate AI analysis via SQLC.
 		// UpsertBoard does NOT update verified_points (it's not in the SQL),
-		// so direct SQL is the only way to set it — same pattern as TestGameService_AddCommit.
-		_, err = env.Pool.Exec(ctx,
-			"UPDATE boards SET verified_points = 15 WHERE id = $1", board1.ID)
+		// so we use the new UpdateBoardVerifiedPoints query.
+		_, err = env.Queries.UpdateBoardVerifiedPoints(ctx, db.UpdateBoardVerifiedPointsParams{
+			BoardID:        board1.ID,
+			VerifiedPoints: 15,
+		})
 		require.NoError(t, err)
 
 		// Verify game 1 board now has verified_points = 15
@@ -529,12 +547,17 @@ func TestGameService_ScoreReset(t *testing.T) {
 		require.NoError(t, err)
 		game2 := testutil.CreateActiveGame(t, env)
 
-		// Add a commit through game 2 (same project)
-		commitID2 := uuid.New()
-		_, err = env.Pool.Exec(ctx,
-			"INSERT INTO commits (id, hash, project_id, author, email, message, url, timestamp) "+
-				"VALUES ($1, $2, $3, 'Verified User 1', 'verifieduser1@test.com', 'Commit 2', 'http://test', now())",
-			commitID2, "verified2-commit-0", project1.ID)
+		// Add a commit via SQLC for game 2 (same project)
+		_, err = env.Queries.CreateCommitSimple(ctx, db.CreateCommitSimpleParams{
+			ID:        db.NewID(),
+			Hash:      db.Text("verified2-commit-0"),
+			ProjectID: project1.ID,
+			Author:    db.Text("Verified User 1"),
+			Email:     db.Text("verifieduser1@test.com"),
+			Message:   "Commit 2",
+			Url:       "http://test",
+			Timestamp: time.Now(),
+		})
 		require.NoError(t, err)
 
 		commit2, err := env.Queries.GetCommitByHashStr(ctx, "verified2-commit-0")
@@ -564,16 +587,22 @@ func TestGameService_ScoreReset(t *testing.T) {
 		project := testutil.CreateProject(t, env, "totalgame-proj",
 			"https://github.com/totaluser/totalgame-proj")
 
-		// Add 2 commits through game 1
+		// Add 2 commits via SQLC
 		for i := 0; i < 2; i++ {
-			commitID := uuid.New()
-			_, err := env.Pool.Exec(ctx,
-				"INSERT INTO commits (id, hash, project_id, author, email, message, url, timestamp) "+
-					"VALUES ($1, $2, $3, 'Total User', 'totaluser@test.com', 'Commit %d', 'http://test', now())",
-				commitID, fmt.Sprintf("total-commit-%d", i), project.ID)
+			commitHash := fmt.Sprintf("total-commit-%d", i)
+			_, err := env.Queries.CreateCommitSimple(ctx, db.CreateCommitSimpleParams{
+				ID:        db.NewID(),
+				Hash:      db.Text(commitHash),
+				ProjectID: project.ID,
+				Author:    db.Text("Total User"),
+				Email:     db.Text("totaluser@test.com"),
+				Message:   fmt.Sprintf("Commit %d", i),
+				Url:       "http://test",
+				Timestamp: time.Now(),
+			})
 			require.NoError(t, err)
 
-			commit, err := env.Queries.GetCommitByHashStr(ctx, fmt.Sprintf("total-commit-%d", i))
+			commit, err := env.Queries.GetCommitByHashStr(ctx, commitHash)
 			require.NoError(t, err)
 			err = svc.AddCommit(ctx, commit)
 			require.NoError(t, err)
@@ -591,9 +620,11 @@ func TestGameService_ScoreReset(t *testing.T) {
 			"board.points should be 12 (2 commits * 1 + 1 project * 10)")
 		assert.Equal(t, int32(0), board.VerifiedPoints)
 
-		// Simulate AI analysis by manually setting verified_points = 5
-		_, err = env.Pool.Exec(ctx,
-			"UPDATE boards SET verified_points = 5 WHERE id = $1", board.ID)
+		// Simulate AI analysis by setting verified_points = 5 via SQLC
+		_, err = env.Queries.UpdateBoardVerifiedPoints(ctx, db.UpdateBoardVerifiedPointsParams{
+			BoardID:        board.ID,
+			VerifiedPoints: 5,
+		})
 		require.NoError(t, err)
 
 		// Verify the computed total: 12 + 5 = 17


### PR DESCRIPTION
- New game Board rows start fresh (no carryover from old games)
- Existing boards.verified_points from prior games remain unchanged
- Total score correctly combines boards.points + boards.verified_points
- Add CreateCommitSimple: insert a commit without user_id/game_id/languages/files
- Add UpdateBoardVerifiedPoints: update a board's verified_points column
- Rewrote TestGameService_ScoreReset to use these new SQLC queries instead of raw SQL for commit insertion and verified_points updates.

Closes: https://github.com/julython/julython.org/issues/187