### PR TITLE
feat: oauth usernames prefixed with provider, webhook users linked on…

### DIFF
--- a/internal/db/commits.sql.go
+++ b/internal/db/commits.sql.go
@@ -489,7 +489,7 @@ SELECT
     c.message,
     c.timestamp,
     c.author,
-    u.username,
+    u.name,
     u.avatar_url,
     p.slug AS project_slug,
     p.name AS project_name
@@ -512,7 +512,7 @@ type GetRecentCommitsRow struct {
 	Message     string      `json:"message"`
 	Timestamp   time.Time   `json:"timestamp"`
 	Author      pgtype.Text `json:"author"`
-	Username    pgtype.Text `json:"username"`
+	Name        pgtype.Text `json:"name"`
 	AvatarUrl   pgtype.Text `json:"avatar_url"`
 	ProjectSlug string      `json:"project_slug"`
 	ProjectName string      `json:"project_name"`
@@ -533,7 +533,7 @@ func (q *Queries) GetRecentCommits(ctx context.Context, arg GetRecentCommitsPara
 			&i.Message,
 			&i.Timestamp,
 			&i.Author,
-			&i.Username,
+			&i.Name,
 			&i.AvatarUrl,
 			&i.ProjectSlug,
 			&i.ProjectName,

--- a/internal/db/helpers.go
+++ b/internal/db/helpers.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -52,6 +53,32 @@ func UUIDFromPg(u pgtype.UUID) uuid.UUID {
 		return uuid.UUID{}
 	}
 	return u.Bytes
+}
+
+// NullString returns an invalid (NULL) pgtype.Text.
+func NullString() pgtype.Text {
+	return pgtype.Text{}
+}
+
+// JSONB serializes a map into a JSONB byte slice.
+// Returns {} if the input is nil.
+func JSONB(data map[string]any) []byte {
+	if data == nil {
+		return []byte("{}")
+	}
+	b, _ := json.Marshal(data)
+	return b
+}
+
+// FromJSONB deserializes a JSONB byte slice into a map.
+// Returns nil if the input is empty.
+func FromJSONB(data []byte) map[string]any {
+	if len(data) == 0 {
+		return nil
+	}
+	var m map[string]any
+	json.Unmarshal(data, &m)
+	return m
 }
 
 // GetCommitByHashStr looks up a commit by its hash string.

--- a/internal/db/queries/commits.sql
+++ b/internal/db/queries/commits.sql
@@ -87,7 +87,7 @@ SELECT
     c.message,
     c.timestamp,
     c.author,
-    u.username,
+    u.name,
     u.avatar_url,
     p.slug AS project_slug,
     p.name AS project_name

--- a/internal/features/game/activity.go
+++ b/internal/features/game/activity.go
@@ -42,7 +42,7 @@ func (h *gameHandler) Activity(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get recent commits for the activity page
-	recentCommits := h.getRecentCommits(ctx, game.ID, 50)
+	recentCommits := h.getRecentCommits(ctx, game.ID, 10)
 
 	layout := layout.LayoutData{
 		Title:       "Recent Activity",
@@ -68,8 +68,8 @@ func (h *gameHandler) getRecentCommits(ctx context.Context, gameID uuid.UUID, li
 	for i, row := range rows {
 		username := row.Author.String
 		avatarURL := ""
-		if row.Username.Valid {
-			username = row.Username.String
+		if row.Name.Valid {
+			username = row.Name.String
 		}
 		if row.AvatarUrl.Valid {
 			avatarURL = row.AvatarUrl.String

--- a/internal/features/game/handler.go
+++ b/internal/features/game/handler.go
@@ -48,7 +48,7 @@ func (h *gameHandler) Home(w http.ResponseWriter, r *http.Request) {
 
 	dailyCommits, maxDay := h.getDailyCommits(ctx, game.ID, game.StartsAt)
 
-	recentCommits := h.getRecentCommits(ctx, game.ID, maxDay)
+	recentCommits := h.getRecentCommits(ctx, game.ID, 10)
 
 	data := HomeData{
 		Game: GameStats{

--- a/internal/features/game/leaderboard.go
+++ b/internal/features/game/leaderboard.go
@@ -52,6 +52,7 @@ func (h *gameHandler) Leaders(w http.ResponseWriter, r *http.Request) {
 			Rank:         offset + i + 1,
 			UserID:       row.UserID.String(),
 			Username:     row.Username,
+			Name:       row.Name,
 			AvatarURL:    avatarURL,
 			CommitCount:  int(row.CommitCount),
 			ProjectCount: int(row.ProjectCount),

--- a/internal/features/game/leaderboard.templ
+++ b/internal/features/game/leaderboard.templ
@@ -13,6 +13,7 @@ import (
 type LeaderboardEntry struct {
 	Rank         int
 	UserID       string
+	Name         string
 	Username     string
 	AvatarURL    string
 	CommitCount  int
@@ -127,7 +128,7 @@ templ LeaderboardRow(entry LeaderboardEntry) {
 		<td class="px-6 py-4">
 			<a href={ templ.SafeURL(fmt.Sprintf("/player/%s", entry.Username)) } class="flex items-center gap-3 group">
 				@avatar.AvatarFallback(entry.Username, entry.AvatarURL, avatar.AvatarLg)
-				<span class="font-medium text-white group-hover:text-july-400 transition-colors">{ entry.Username }</span>
+				<span class="font-medium text-white group-hover:text-july-400 transition-colors">{ entry.Name }</span>
 			</a>
 		</td>
 		<td class="px-6 py-4 text-right text-gray-400">{ fmt.Sprintf("%d", entry.CommitCount) }</td>

--- a/internal/features/game/leaderboard_templ.go
+++ b/internal/features/game/leaderboard_templ.go
@@ -21,6 +21,7 @@ import (
 type LeaderboardEntry struct {
 	Rank         int
 	UserID       string
+	Name         string
 	Username     string
 	AvatarURL    string
 	CommitCount  int
@@ -113,7 +114,7 @@ func LeaderboardPage(ld layout.LayoutData, data LeaderboardData) templ.Component
 			var templ_7745c5c3_Var3 string
 			templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(i18n.T(ctx, "Leaderboard"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 72, Col: 79}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 73, Col: 79}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 			if templ_7745c5c3_Err != nil {
@@ -126,7 +127,7 @@ func LeaderboardPage(ld layout.LayoutData, data LeaderboardData) templ.Component
 			var templ_7745c5c3_Var4 string
 			templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(data.Game.Name)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 74, Col: 21}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 75, Col: 21}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 			if templ_7745c5c3_Err != nil {
@@ -139,7 +140,7 @@ func LeaderboardPage(ld layout.LayoutData, data LeaderboardData) templ.Component
 			var templ_7745c5c3_Var5 string
 			templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d %s", data.TotalUsers, i18n.T(ctx, "Participants")))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 74, Col: 96}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 75, Col: 96}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 			if templ_7745c5c3_Err != nil {
@@ -209,7 +210,7 @@ func LeaderboardTable(data LeaderboardData) templ.Component {
 			var templ_7745c5c3_Var7 string
 			templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(i18n.T(ctx, "Rank"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 93, Col: 76}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 94, Col: 76}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 			if templ_7745c5c3_Err != nil {
@@ -222,7 +223,7 @@ func LeaderboardTable(data LeaderboardData) templ.Component {
 			var templ_7745c5c3_Var8 string
 			templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(i18n.T(ctx, "Coder"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 94, Col: 72}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 95, Col: 72}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 			if templ_7745c5c3_Err != nil {
@@ -235,7 +236,7 @@ func LeaderboardTable(data LeaderboardData) templ.Component {
 			var templ_7745c5c3_Var9 string
 			templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(i18n.T(ctx, "Commits"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 95, Col: 75}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 96, Col: 75}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 			if templ_7745c5c3_Err != nil {
@@ -248,7 +249,7 @@ func LeaderboardTable(data LeaderboardData) templ.Component {
 			var templ_7745c5c3_Var10 string
 			templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(i18n.T(ctx, "Projects"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 96, Col: 76}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 97, Col: 76}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 			if templ_7745c5c3_Err != nil {
@@ -261,7 +262,7 @@ func LeaderboardTable(data LeaderboardData) templ.Component {
 			var templ_7745c5c3_Var11 string
 			templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(i18n.T(ctx, "Points"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 97, Col: 74}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 98, Col: 74}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 			if templ_7745c5c3_Err != nil {
@@ -289,7 +290,7 @@ func LeaderboardTable(data LeaderboardData) templ.Component {
 				var templ_7745c5c3_Var12 string
 				templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("/leaders?offset=%d", data.Offset+data.Limit))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 110, Col: 71}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 111, Col: 71}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 				if templ_7745c5c3_Err != nil {
@@ -302,7 +303,7 @@ func LeaderboardTable(data LeaderboardData) templ.Component {
 				var templ_7745c5c3_Var13 string
 				templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(i18n.T(ctx, "LoadMore"))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 115, Col: 30}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 116, Col: 30}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
 				if templ_7745c5c3_Err != nil {
@@ -372,7 +373,7 @@ func LeaderboardRow(entry LeaderboardEntry) templ.Component {
 		var templ_7745c5c3_Var17 templ.SafeURL
 		templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(fmt.Sprintf("/player/%s", entry.Username)))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 128, Col: 69}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 129, Col: 69}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 		if templ_7745c5c3_Err != nil {
@@ -391,9 +392,9 @@ func LeaderboardRow(entry LeaderboardEntry) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var18 string
-		templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(entry.Username)
+		templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(entry.Name)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 130, Col: 101}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 131, Col: 97}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
 		if templ_7745c5c3_Err != nil {
@@ -406,7 +407,7 @@ func LeaderboardRow(entry LeaderboardEntry) templ.Component {
 		var templ_7745c5c3_Var19 string
 		templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", entry.CommitCount))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 133, Col: 87}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 134, Col: 87}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
 		if templ_7745c5c3_Err != nil {
@@ -419,7 +420,7 @@ func LeaderboardRow(entry LeaderboardEntry) templ.Component {
 		var templ_7745c5c3_Var20 string
 		templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", entry.ProjectCount))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 134, Col: 88}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 135, Col: 88}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
 		if templ_7745c5c3_Err != nil {
@@ -432,7 +433,7 @@ func LeaderboardRow(entry LeaderboardEntry) templ.Component {
 		var templ_7745c5c3_Var21 string
 		templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", entry.Points))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 136, Col: 74}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 137, Col: 74}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
 		if templ_7745c5c3_Err != nil {
@@ -489,7 +490,7 @@ func ProjectLeaderboardPage(ld layout.LayoutData, data ProjectLeaderboardData) t
 			var templ_7745c5c3_Var24 string
 			templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinStringErrs(i18n.T(ctx, "ProjectLeaderboard"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 148, Col: 86}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 149, Col: 86}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var24))
 			if templ_7745c5c3_Err != nil {
@@ -502,7 +503,7 @@ func ProjectLeaderboardPage(ld layout.LayoutData, data ProjectLeaderboardData) t
 			var templ_7745c5c3_Var25 string
 			templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(data.Game.Name)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 149, Col: 45}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 150, Col: 45}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
 			if templ_7745c5c3_Err != nil {
@@ -572,7 +573,7 @@ func ProjectLeaderboardTable(data ProjectLeaderboardData) templ.Component {
 			var templ_7745c5c3_Var27 string
 			templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs(i18n.T(ctx, "Rank"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 167, Col: 76}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 168, Col: 76}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
 			if templ_7745c5c3_Err != nil {
@@ -585,7 +586,7 @@ func ProjectLeaderboardTable(data ProjectLeaderboardData) templ.Component {
 			var templ_7745c5c3_Var28 string
 			templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs(i18n.T(ctx, "Project"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 168, Col: 74}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 169, Col: 74}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var28))
 			if templ_7745c5c3_Err != nil {
@@ -598,7 +599,7 @@ func ProjectLeaderboardTable(data ProjectLeaderboardData) templ.Component {
 			var templ_7745c5c3_Var29 string
 			templ_7745c5c3_Var29, templ_7745c5c3_Err = templ.JoinStringErrs(i18n.T(ctx, "Contributors"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 169, Col: 80}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 170, Col: 80}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var29))
 			if templ_7745c5c3_Err != nil {
@@ -611,7 +612,7 @@ func ProjectLeaderboardTable(data ProjectLeaderboardData) templ.Component {
 			var templ_7745c5c3_Var30 string
 			templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.JoinStringErrs(i18n.T(ctx, "Commits"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 170, Col: 75}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 171, Col: 75}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var30))
 			if templ_7745c5c3_Err != nil {
@@ -624,7 +625,7 @@ func ProjectLeaderboardTable(data ProjectLeaderboardData) templ.Component {
 			var templ_7745c5c3_Var31 string
 			templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.JoinStringErrs(i18n.T(ctx, "Points"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 171, Col: 74}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 172, Col: 74}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var31))
 			if templ_7745c5c3_Err != nil {
@@ -652,7 +653,7 @@ func ProjectLeaderboardTable(data ProjectLeaderboardData) templ.Component {
 				var templ_7745c5c3_Var32 string
 				templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.JoinStringErrs(i18n.T(ctx, "TopProjectsShown"))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 183, Col: 70}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 184, Col: 70}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var32))
 				if templ_7745c5c3_Err != nil {
@@ -722,7 +723,7 @@ func ProjectLeaderboardRow(entry ProjectLeaderboardEntry) templ.Component {
 		var templ_7745c5c3_Var36 templ.SafeURL
 		templ_7745c5c3_Var36, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(fmt.Sprintf("/projects/%s", entry.Slug)))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 195, Col: 67}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 196, Col: 67}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var36))
 		if templ_7745c5c3_Err != nil {
@@ -735,7 +736,7 @@ func ProjectLeaderboardRow(entry ProjectLeaderboardEntry) templ.Component {
 		var templ_7745c5c3_Var37 string
 		templ_7745c5c3_Var37, templ_7745c5c3_Err = templ.JoinStringErrs(entry.ProjectName)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 196, Col: 104}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 197, Col: 104}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var37))
 		if templ_7745c5c3_Err != nil {
@@ -748,7 +749,7 @@ func ProjectLeaderboardRow(entry ProjectLeaderboardEntry) templ.Component {
 		var templ_7745c5c3_Var38 string
 		templ_7745c5c3_Var38, templ_7745c5c3_Err = templ.JoinStringErrs(entry.Slug)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 197, Col: 58}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 198, Col: 58}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var38))
 		if templ_7745c5c3_Err != nil {
@@ -761,7 +762,7 @@ func ProjectLeaderboardRow(entry ProjectLeaderboardEntry) templ.Component {
 		var templ_7745c5c3_Var39 string
 		templ_7745c5c3_Var39, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", entry.ContributorCount))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 200, Col: 92}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 201, Col: 92}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var39))
 		if templ_7745c5c3_Err != nil {
@@ -774,7 +775,7 @@ func ProjectLeaderboardRow(entry ProjectLeaderboardEntry) templ.Component {
 		var templ_7745c5c3_Var40 string
 		templ_7745c5c3_Var40, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", entry.CommitCount))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 201, Col: 87}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 202, Col: 87}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var40))
 		if templ_7745c5c3_Err != nil {
@@ -788,7 +789,7 @@ func ProjectLeaderboardRow(entry ProjectLeaderboardEntry) templ.Component {
 			var templ_7745c5c3_Var41 string
 			templ_7745c5c3_Var41, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", entry.VerifiedPoints))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 205, Col: 46}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 206, Col: 46}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var41))
 			if templ_7745c5c3_Err != nil {
@@ -798,7 +799,7 @@ func ProjectLeaderboardRow(entry ProjectLeaderboardEntry) templ.Component {
 			var templ_7745c5c3_Var42 string
 			templ_7745c5c3_Var42, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", entry.PotentialPoints))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 207, Col: 47}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 208, Col: 47}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var42))
 			if templ_7745c5c3_Err != nil {
@@ -856,7 +857,7 @@ func LanguageLeaderboardPage(ld layout.LayoutData, data LanguageLeaderboardData)
 			var templ_7745c5c3_Var45 string
 			templ_7745c5c3_Var45, templ_7745c5c3_Err = templ.JoinStringErrs(i18n.T(ctx, "LanguageLeaderboard"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 221, Col: 87}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 222, Col: 87}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var45))
 			if templ_7745c5c3_Err != nil {
@@ -869,7 +870,7 @@ func LanguageLeaderboardPage(ld layout.LayoutData, data LanguageLeaderboardData)
 			var templ_7745c5c3_Var46 string
 			templ_7745c5c3_Var46, templ_7745c5c3_Err = templ.JoinStringErrs(data.Game.Name)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 222, Col: 45}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 223, Col: 45}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var46))
 			if templ_7745c5c3_Err != nil {
@@ -939,7 +940,7 @@ func LanguageLeaderboardTable(data LanguageLeaderboardData) templ.Component {
 			var templ_7745c5c3_Var48 string
 			templ_7745c5c3_Var48, templ_7745c5c3_Err = templ.JoinStringErrs(i18n.T(ctx, "Rank"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 240, Col: 76}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 241, Col: 76}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var48))
 			if templ_7745c5c3_Err != nil {
@@ -952,7 +953,7 @@ func LanguageLeaderboardTable(data LanguageLeaderboardData) templ.Component {
 			var templ_7745c5c3_Var49 string
 			templ_7745c5c3_Var49, templ_7745c5c3_Err = templ.JoinStringErrs(i18n.T(ctx, "Language"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 241, Col: 75}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 242, Col: 75}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var49))
 			if templ_7745c5c3_Err != nil {
@@ -965,7 +966,7 @@ func LanguageLeaderboardTable(data LanguageLeaderboardData) templ.Component {
 			var templ_7745c5c3_Var50 string
 			templ_7745c5c3_Var50, templ_7745c5c3_Err = templ.JoinStringErrs(i18n.T(ctx, "Commits"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 242, Col: 75}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 243, Col: 75}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var50))
 			if templ_7745c5c3_Err != nil {
@@ -978,7 +979,7 @@ func LanguageLeaderboardTable(data LanguageLeaderboardData) templ.Component {
 			var templ_7745c5c3_Var51 string
 			templ_7745c5c3_Var51, templ_7745c5c3_Err = templ.JoinStringErrs(i18n.T(ctx, "Points"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 243, Col: 74}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 244, Col: 74}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var51))
 			if templ_7745c5c3_Err != nil {
@@ -1057,7 +1058,7 @@ func LanguageLeaderboardRow(entry LanguageLeaderboardEntry) templ.Component {
 		var templ_7745c5c3_Var55 string
 		templ_7745c5c3_Var55, templ_7745c5c3_Err = templ.JoinStringErrs(entry.LanguageName)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 262, Col: 60}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 263, Col: 60}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var55))
 		if templ_7745c5c3_Err != nil {
@@ -1070,7 +1071,7 @@ func LanguageLeaderboardRow(entry LanguageLeaderboardEntry) templ.Component {
 		var templ_7745c5c3_Var56 string
 		templ_7745c5c3_Var56, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", entry.CommitCount))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 264, Col: 87}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 265, Col: 87}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var56))
 		if templ_7745c5c3_Err != nil {
@@ -1083,7 +1084,7 @@ func LanguageLeaderboardRow(entry LanguageLeaderboardEntry) templ.Component {
 		var templ_7745c5c3_Var57 string
 		templ_7745c5c3_Var57, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", entry.Points))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 266, Col: 74}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 267, Col: 74}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var57))
 		if templ_7745c5c3_Err != nil {
@@ -1194,7 +1195,7 @@ func rankCell(rank int) templ.Component {
 			var templ_7745c5c3_Var60 string
 			templ_7745c5c3_Var60, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("#%d", rank))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 307, Col: 69}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 308, Col: 69}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var60))
 			if templ_7745c5c3_Err != nil {

--- a/internal/features/players/players.templ
+++ b/internal/features/players/players.templ
@@ -21,7 +21,7 @@ templ PlayersPage(ld layout.LayoutData, data PlayersData) {
 	@layout.Layout(ld) {
 		<main class="max-w-7xl mx-auto px-4 py-8">
 			<div class="flex items-center gap-4 mb-8">
-				<span class="text-3xl font-bold text-july-400">{ data.Username }</span>
+				<span class="text-3xl font-bold text-july-400">{ data.Name }</span>
 			</div>
 			if len(data.Boards) == 0 {
 				@noBoardsState()

--- a/internal/features/players/players_templ.go
+++ b/internal/features/players/players_templ.go
@@ -63,9 +63,9 @@ func PlayersPage(ld layout.LayoutData, data PlayersData) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var3 string
-			templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(data.Username)
+			templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(data.Name)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/players/players.templ`, Line: 24, Col: 66}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/players/players.templ`, Line: 24, Col: 62}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 			if templ_7745c5c3_Err != nil {

--- a/internal/services/oauth.go
+++ b/internal/services/oauth.go
@@ -172,7 +172,7 @@ func (g *GitHubOAuth) fetchUser(ctx context.Context, token string) (OAuthUser, e
 	return OAuthUser{
 		ID:        fmt.Sprintf("%d", data.ID),
 		Provider:  "github",
-		Username:  data.Login,
+		Username:  "gh-" + data.Login,
 		Name:      data.Name,
 		AvatarURL: data.AvatarURL,
 	}, nil
@@ -359,7 +359,7 @@ func (g *GitLabOAuth) GetUser(ctx context.Context, tokens OAuthTokens) (OAuthUse
 	user := OAuthUser{
 		ID:        fmt.Sprintf("%d", data.ID),
 		Provider:  "gitlab",
-		Username:  data.Username,
+		Username:  "gl-" + data.Username,
 		Name:      data.Name,
 		AvatarURL: data.AvatarURL,
 		Data: map[string]any{

--- a/internal/services/users.go
+++ b/internal/services/users.go
@@ -3,14 +3,12 @@ package services
 import (
 	"context"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/rs/zerolog/log"
 
 	"july/internal/db"
@@ -121,7 +119,7 @@ func (s *UserService) UpsertIdentifier(
 		UserID:    userID,
 		Verified:  verified,
 		IsPrimary: primary,
-		Data:      toJSONB(encrypted),
+		Data:      db.JSONB(encrypted),
 	})
 	if err != nil {
 		return db.UserIdentifier{}, false, err
@@ -149,8 +147,8 @@ func (s *UserService) OAuthLoginOrRegister(ctx context.Context, oauth OAuthUser)
 		// Update user info
 		err = s.queries.UpdateUser(ctx, db.UpdateUserParams{
 			ID:        user.ID,
-			Name:      toNullString(coalesce(oauth.Name, user.Name)),
-			AvatarUrl: toNullString(coalesce(oauth.AvatarURL, stringFromNull(user.AvatarUrl))),
+			Name:      db.Text(coalesce(oauth.Name, user.Name)),
+			AvatarUrl: db.Text(coalesce(oauth.AvatarURL, db.StringFromNull(user.AvatarUrl))),
 		})
 		if err != nil {
 			return db.User{}, false, err
@@ -192,12 +190,43 @@ func (s *UserService) OAuthLoginOrRegister(ctx context.Context, oauth OAuthUser)
 		return *existingUser, false, nil
 	}
 
+	// 2b. Check if a webhook-created user has this username (Task 1 created users)
+	// OAuth usernames are prefixed (gh-xxx, gl-xxx). Webhook users are also prefixed.
+	if oauth.Username != "" {
+		if user, err := s.queries.GetUserByUsername(ctx, oauth.Username); err == nil {
+			// Link OAuth identity to this webhook-created user
+			if _, _, err := s.UpsertIdentifier(ctx, user.ID, idType, oauth.ID, oauth.Data, true, false); err != nil {
+				return db.User{}, false, err
+			}
+
+			// Update name and avatar from OAuth data
+			if err := s.queries.UpdateUser(ctx, db.UpdateUserParams{
+				ID:        user.ID,
+				Name:      db.Text(coalesce(oauth.Name, user.Name)),
+				AvatarUrl: db.Text(coalesce(oauth.AvatarURL, db.StringFromNull(user.AvatarUrl))),
+			}); err != nil {
+				return db.User{}, false, err
+			}
+
+			// Refresh user after update
+			user, _ = s.queries.GetUserByID(ctx, user.ID)
+
+			// Add verified emails from OAuth
+			if _, err := s.upsertEmails(ctx, user.ID, verifiedEmails); err != nil {
+				return db.User{}, false, err
+			}
+
+			logger.Info().Str("user_id", user.ID.String()).Str("username", oauth.Username).Msg("oauth linked to webhook-created user")
+			return user, false, nil
+		}
+	}
+
 	// 3. Create new user
 	newUser, err := s.queries.CreateUser(ctx, db.CreateUserParams{
 		ID:        db.NewID(),
 		Username:  oauth.Username,
 		Name:      oauth.Name,
-		AvatarUrl: toNullString(oauth.AvatarURL),
+		AvatarUrl: db.Text(oauth.AvatarURL),
 		Role:      "user",
 	})
 	if err != nil {
@@ -226,7 +255,7 @@ func (s *UserService) GetOAuthToken(ctx context.Context, userID uuid.UUID, provi
 	if err != nil {
 		return "", err
 	}
-	data := fromJSONB(identifier.Data)
+	data := db.FromJSONB(identifier.Data)
 	token, _ := data["access_token"].(string)
 	if token == "" {
 		return "", fmt.Errorf("no access token found for %s", provider)
@@ -344,37 +373,6 @@ func coalesce(a, b string) string {
 		return a
 	}
 	return b
-}
-
-func toNullString(s string) pgtype.Text {
-	if s == "" {
-		return pgtype.Text{Valid: false}
-	}
-	return pgtype.Text{String: s, Valid: true}
-}
-
-func stringFromNull(t pgtype.Text) string {
-	if t.Valid {
-		return t.String
-	}
-	return ""
-}
-
-func toJSONB(data map[string]any) []byte {
-	if data == nil {
-		return []byte("{}")
-	}
-	b, _ := json.Marshal(data)
-	return b
-}
-
-func fromJSONB(data []byte) map[string]any {
-	if len(data) == 0 {
-		return nil
-	}
-	var m map[string]any
-	json.Unmarshal(data, &m)
-	return m
 }
 
 // UpdateProfile updates the user's name and avatar URL

--- a/internal/services/users_test.go
+++ b/internal/services/users_test.go
@@ -1,0 +1,110 @@
+package services_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"july/internal/db"
+	"july/internal/services"
+	"july/internal/testutil"
+)
+
+func TestOAuthLoginWebhookUser(t *testing.T) {
+	env := testutil.SetupTestEnv(t)
+	ctx := context.Background()
+
+	t.Run("webhook-created user linked by OAuth", func(t *testing.T) {
+		// 1. Create a webhook-created user (gh-prefixed username) WITHOUT email identifier.
+		// This ensures the OAuth flow finds them by step 2b (username lookup),
+		// NOT by step 2 (email lookup).
+		webhookUser, err := env.Queries.CreateUser(ctx, db.CreateUserParams{
+			ID:       db.NewID(),
+			Username: "gh-testwebhook",
+			Name:     "Webhook User",
+			Role:     "user",
+		})
+		require.NoError(t, err)
+
+		// 2. Verify the user was created with the correct username
+		lookupUser, err := env.Queries.GetUserByUsername(ctx, "gh-testwebhook")
+		require.NoError(t, err)
+		assert.Equal(t, "gh-testwebhook", lookupUser.Username)
+		assert.Equal(t, "Webhook User", lookupUser.Name)
+
+		// 3. Simulate OAuth login from a GitHub OAuth provider.
+		// This user has a username matching the webhook user, but NO email match.
+		oauthUser := services.OAuthUser{
+			Provider:  "github",
+			Username:  "gh-testwebhook",
+			ID:        "12345",
+			Name:      "Test User OAuth",
+			AvatarURL: "https://github.com/testwebhook.png",
+			Emails: []services.EmailAddress{
+				{Email: "different@example.com", Primary: true, Verified: true},
+			},
+			Data: map[string]any{
+				"access_token": "oauth-token-123",
+				"scope":        "user:email",
+			},
+		}
+
+		// 4. Call OAuthLoginOrRegister — should find the webhook user by username (step 2b),
+		// not create a new user, not find by email
+		resultUser, created, err := env.UserService.OAuthLoginOrRegister(ctx, oauthUser)
+		require.NoError(t, err)
+
+		// 5. Verify: the existing webhook user was returned, not a new user
+		assert.False(t, created, "should not create a new user when webhook user exists")
+		assert.Equal(t, webhookUser.ID, resultUser.ID, "should link to existing webhook user")
+
+		// 6. Verify: GitHub identifier was added
+		ghID, err := env.Queries.GetUserIdentifierByUserAndType(ctx, db.GetUserIdentifierByUserAndTypeParams{
+			UserID: webhookUser.ID,
+			Type:   "github",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "github:12345", ghID.Value, "should have github identifier")
+
+		// 7. Verify: name was updated from OAuth data
+		actualUser, err := env.Queries.GetUserByID(ctx, resultUser.ID)
+		require.NoError(t, err)
+		assert.Equal(t, "Test User OAuth", actualUser.Name, "name should be updated from OAuth data")
+	})
+
+	t.Run("new OAuth user creates fresh account", func(t *testing.T) {
+		// A user who has never committed — fresh OAuth signup
+		oauthUser := services.OAuthUser{
+			Provider:  "github",
+			Username:  "gh-freshuser",
+			ID:        "99999",
+			Name:      "Fresh User",
+			AvatarURL: "https://github.com/freshuser.png",
+			Emails: []services.EmailAddress{
+				{Email: "fresh@example.com", Primary: true, Verified: true},
+			},
+			Data: map[string]any{
+				"access_token": "oauth-token-456",
+				"scope":        "user:email",
+			},
+		}
+
+		resultUser, created, err := env.UserService.OAuthLoginOrRegister(ctx, oauthUser)
+		require.NoError(t, err)
+
+		assert.True(t, created, "should create a new user for fresh OAuth")
+
+		// Verify user has the right username
+		assert.Equal(t, "gh-freshuser", resultUser.Username)
+
+		// Verify GitHub identifier was added
+		ghID, err := env.Queries.GetUserIdentifierByUserAndType(ctx, db.GetUserIdentifierByUserAndTypeParams{
+			UserID: resultUser.ID,
+			Type:   "github",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "github:99999", ghID.Value)
+	})
+}

--- a/internal/testutil/db.go
+++ b/internal/testutil/db.go
@@ -3,8 +3,8 @@ package testutil
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -30,8 +30,9 @@ import (
 	"july/internal/config"
 	"july/internal/db"
 
-	"july/internal/services"
 	"july/internal/i18n"
+	"july/internal/services"
+
 	"github.com/google/uuid"
 )
 
@@ -50,6 +51,7 @@ type TestEnv struct {
 	Pool        *pgxpool.Pool
 	Queries     *db.Queries
 	GameService *services.GameService
+	UserService *services.UserService
 }
 
 // SetupSharedEnv initializes the shared container, pool, and config once.
@@ -157,6 +159,7 @@ func SetupTestEnv(t *testing.T) *TestEnv {
 		Server:      server,
 		Client:      server.Client(),
 		GameService: services.NewGameService(queries),
+		UserService: services.MustNewUserService(queries, sharedCfg.Database.EncKey),
 	}
 }
 

--- a/internal/webhooks/github.go
+++ b/internal/webhooks/github.go
@@ -386,7 +386,8 @@ func (h *Handler) getOrCreateUserForCommit(ctx context.Context, author GitHubAut
 
 	// Stage 1: Look up by username (skip if empty — webhooks may not include it)
 	if author.Username != "" {
-		if user, err := h.queries.GetUserByUsername(ctx, author.Username); err == nil {
+		prefixedUsername := "gh-" + author.Username
+		if user, err := h.queries.GetUserByUsername(ctx, prefixedUsername); err == nil {
 			// Found by username — add email as unverified identifier
 			// (name/avatar update is handled by processCommits with dedup)
 			// Use UpsertUserIdentifierUnverified to preserve any existing
@@ -417,10 +418,11 @@ func (h *Handler) getOrCreateUserForCommit(ctx context.Context, author GitHubAut
 	var result commitUserResult
 	if author.Username != "" {
 		userID := db.NewID()
+		prefixedUsername := "gh-" + author.Username
 		user, err := h.queries.CreateUser(ctx, db.CreateUserParams{
 			ID:        userID,
 			Name:      author.Name,
-			Username:  author.Username,
+			Username:  prefixedUsername,
 			AvatarUrl: db.Text(author.AvatarURL),
 			Role:      "user",
 		})

--- a/internal/webhooks/github_test.go
+++ b/internal/webhooks/github_test.go
@@ -447,7 +447,7 @@ func TestGitHubWebhook(t *testing.T) {
 
 	t.Run("finds existing user by username", func(t *testing.T) {
 		// User "frank" exists with username "frank"
-		user := testutil.CreateUser(t, env, "frank", "Frank Username")
+		user := testutil.CreateUser(t, env, "gh-frank", "Frank Username")
 		testutil.CreateUserIdentifier(t, env, user.ID, "email", "frank@example.com", false, true)
 
 		// Commit has matching username "frank" → should find by username, not email
@@ -502,7 +502,7 @@ func TestGitHubWebhook(t *testing.T) {
 	t.Run("existing user with verified email not overwritten by webhook", func(t *testing.T) {
 		// User "eve" has a verified email. A commit from eve matching her email
 		// should NOT overwrite her verified/primary status.
-		user := testutil.CreateUser(t, env, "eve", "Eve Developer")
+		user := testutil.CreateUser(t, env, "gh-eve", "Eve Developer")
 		testutil.CreateUserIdentifier(t, env, user.ID, "email", "eve@verified.com", true, true)
 
 		payload := webhooks.GitHubPushEvent{
@@ -561,7 +561,7 @@ func TestGitHubWebhook(t *testing.T) {
 		assert.Equal(t, 1, result.Created)
 
 		// Verify user was created
-		user, err := env.Queries.GetUserByUsername(t.Context(), "newgrit")
+		user, err := env.Queries.GetUserByUsername(t.Context(), "gh-newgrit")
 		require.NoError(t, err)
 		assert.Equal(t, "New Grizzard", user.Name)
 
@@ -606,7 +606,7 @@ func TestGitHubWebhook(t *testing.T) {
 		assert.Equal(t, 1, result1.Created)
 
 		// Get the created user
-		user, err := env.Queries.GetUserByUsername(t.Context(), "repmulti")
+		user, err := env.Queries.GetUserByUsername(t.Context(), "gh-repmulti")
 		require.NoError(t, err)
 
 		// Second commit with updated name and avatar
@@ -636,7 +636,7 @@ func TestGitHubWebhook(t *testing.T) {
 		assert.Equal(t, 1, result2.Created)
 
 		// Verify same user was used (not a duplicate)
-		secondUser, err := env.Queries.GetUserByUsername(t.Context(), "repmulti")
+		secondUser, err := env.Queries.GetUserByUsername(t.Context(), "gh-repmulti")
 		require.NoError(t, err)
 		assert.Equal(t, user.ID, secondUser.ID)
 


### PR DESCRIPTION
… first login

- Prefix OAuth usernames: gh-{login}, gl-{username} to avoid collisions
- Webhook handler prefixes usernames with gh- when creating users
- OAuth flow: webhook-created users (step 2b) found by prefixed username and get their github:<id> identifier linked on first login
- Moved helper functions (Text, JSONB, FromJSONB, etc.) to db.helpers
- Cleaned up local copies in services/users.go
- Added helper NewUserService to testutil for service-level tests
- Added test: webhook-created user linked by OAuth (step 2b flow)

Closes: #207