### PR TITLE
test: update tests for multi-stage webhook lookup flow

### DIFF
--- a/internal/auth/auth_integration_test.go
+++ b/internal/auth/auth_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"july/internal/db"
+	"july/internal/services"
 	"july/internal/testutil"
 )
 
@@ -481,6 +482,111 @@ func TestFullLoginLogoutFlow(t *testing.T) {
 	require.NoError(t, err)
 	resp3.Body.Close()
 	assert.Equal(t, http.StatusUnauthorized, resp3.StatusCode)
+}
+
+// ============================================================================
+// OAuth Linking Tests (multi-stage lookup integration)
+// ============================================================================
+
+func TestOAuthLoginLinksToWebhookUser(t *testing.T) {
+	env := testutil.SetupTestEnv(t)
+
+	// Step 1: Create a user via "webhook" — username + unverified email
+	user, err := env.Queries.CreateUser(context.Background(), db.CreateUserParams{
+		ID:       db.NewID(),
+		Name:     "Webhook Creator",
+		Username: "gh-webhookuser",
+		Role:     "user",
+	})
+	require.NoError(t, err)
+
+	// Add unverified email identifier (what webhook does)
+	_, err = env.Queries.UpsertUserIdentifier(context.Background(), db.UpsertUserIdentifierParams{
+		Value:     "email:webhook@example.com",
+		Type:      "email",
+		UserID:    user.ID,
+		Verified:  false,
+		IsPrimary: false,
+	})
+	require.NoError(t, err)
+
+	// Step 2: Simulate OAuth login — should find user by username, add github:<id>
+	oauthUser := services.OAuthUser{
+		ID:        "99999",
+		Provider:  "github",
+		Username:  "gh-webhookuser",
+		Name:      "Webhook Creator Updated",
+		AvatarURL: "https://avatars.example.com/webhook.png",
+		Emails:    []services.EmailAddress{{Email: "webhook@example.com", Primary: true, Verified: true}},
+	}
+
+	linkedUser, created, err := env.UserService.OAuthLoginOrRegister(context.Background(), oauthUser)
+	require.NoError(t, err)
+	assert.False(t, created, "should not create a new user — should find by username")
+	assert.Equal(t, user.ID, linkedUser.ID)
+
+	// Verify github:<id> identifier was added
+	_, err = env.Queries.GetUserIdentifier(context.Background(), "github:99999")
+	require.NoError(t, err, "github identifier should exist after OAuth login")
+
+	// Verify user name was updated from OAuth data
+	updatedUser, err := env.Queries.GetUserByID(context.Background(), linkedUser.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "Webhook Creator Updated", updatedUser.Name)
+
+	// Verify avatar was updated from OAuth data
+	require.True(t, updatedUser.AvatarUrl.Valid)
+	assert.Equal(t, "https://avatars.example.com/webhook.png", db.StringFromNull(updatedUser.AvatarUrl))
+
+	// Verify original email identifier still exists (preserved, not overwritten)
+	_, err = env.Queries.GetUserIdentifier(context.Background(), "email:webhook@example.com")
+	require.NoError(t, err)
+}
+
+func TestOAuthLoginFindsUserByGithubId(t *testing.T) {
+	env := testutil.SetupTestEnv(t)
+
+	// Step 1: Create a user with an existing github:<id> identifier
+	user, err := env.Queries.CreateUser(context.Background(), db.CreateUserParams{
+		ID:       db.NewID(),
+		Name:     "Existing GitHub User",
+		Username: "gh-ghuser",
+		Role:     "user",
+	})
+	require.NoError(t, err)
+
+	// Add the github identifier directly (simulating prior OAuth login)
+	_, err = env.Queries.UpsertUserIdentifier(context.Background(), db.UpsertUserIdentifierParams{
+		Value:     "github:12345",
+		Type:      "github",
+		UserID:    user.ID,
+		Verified:  true,
+		IsPrimary: false,
+	})
+	require.NoError(t, err)
+
+	// Step 2: Simulate OAuth login with matching github ID
+	oauthUser := services.OAuthUser{
+		ID:        "12345",
+		Provider:  "github",
+		Username:  "gh-ghuser",
+		Name:      "GitHub User Updated",
+		AvatarURL: "https://avatars.example.com/ghuser.png",
+	}
+
+	linkedUser, created, err := env.UserService.OAuthLoginOrRegister(context.Background(), oauthUser)
+	require.NoError(t, err)
+	assert.False(t, created, "should not create a new user — should find by github:<id>")
+	assert.Equal(t, user.ID, linkedUser.ID)
+
+	// Verify user name was updated from OAuth data
+	updatedUser, err := env.Queries.GetUserByID(context.Background(), linkedUser.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "GitHub User Updated", updatedUser.Name)
+
+	// Verify avatar was updated from OAuth data
+	require.True(t, updatedUser.AvatarUrl.Valid)
+	assert.Equal(t, "https://avatars.example.com/ghuser.png", db.StringFromNull(updatedUser.AvatarUrl))
 }
 
 // ============================================================================

--- a/internal/testutil/webhooks.go
+++ b/internal/testutil/webhooks.go
@@ -20,34 +20,48 @@ type WebhookOpts struct {
 	RepoName    string
 	FullName    string
 	HTMLURL     string
-	Description string
 	Private     bool
 	Fork        bool
 	ForksCount  int
 	Watchers    int
+	Description string
 	Author      webhooks.GitHubAuthor
+	Username    string
+	AvatarURL   string
 	Files       []string
 	Message     string
 	Timestamp   time.Time
 }
 
+// buildAuthor applies optional username and avatar overrides to an author.
+func buildAuthor(base webhooks.GitHubAuthor, username string, avatarURL string) webhooks.GitHubAuthor {
+	if username != "" {
+		base.Username = username
+	}
+	if avatarURL != "" {
+		base.AvatarURL = avatarURL
+	}
+	return base
+}
+
 // WebhookPayload builds a minimal valid GitHubPushEvent with sensible defaults.
 // Apply option funcs to override specific fields.
 func WebhookPayload(hash string, opts ...func(*WebhookOpts)) webhooks.GitHubPushEvent {
+	author := webhooks.GitHubAuthor{Name: "Test User", Email: "test@example.com"}
 	o := &WebhookOpts{
-		Ref:       "refs/heads/main",
-		RepoID:    12345,
-		RepoName:  "test-repo",
-		FullName:  "testuser/test-repo",
-		HTMLURL:   "https://github.com/testuser/test-repo",
-		Author:    webhooks.GitHubAuthor{Name: "Test User", Email: "test@example.com"},
-		Message:   "Add a meaningful change",
-		Files:     []string{"main.go"},
-		Timestamp: time.Now(),
+		Ref:      "refs/heads/main",
+		RepoID:   12345,
+		RepoName: "test-repo",
+		FullName: "testuser/test-repo",
+		HTMLURL:  "https://github.com/testuser/test-repo",
+		Author:   author,
+		Message:  "Add a meaningful change",
+		Files:    []string{"main.go"},
 	}
 	for _, opt := range opts {
 		opt(o)
 	}
+	author = buildAuthor(o.Author, o.Username, o.AvatarURL)
 	return webhooks.GitHubPushEvent{
 		Ref:    o.Ref,
 		Forced: o.Forced,
@@ -61,16 +75,14 @@ func WebhookPayload(hash string, opts ...func(*WebhookOpts)) webhooks.GitHubPush
 			ForksCount:  o.ForksCount,
 			Watchers:    o.Watchers,
 		},
-		Commits: []webhooks.GitHubCommit{
-			{
-				ID:        hash,
-				Message:   o.Message,
-				Timestamp: o.Timestamp,
-				URL:       o.HTMLURL + "/commit/" + hash,
-				Author:    o.Author,
-				Added:     o.Files,
-			},
-		},
+		Commits: []webhooks.GitHubCommit{{
+			ID:        hash,
+			Message:   o.Message,
+			Timestamp: o.Timestamp,
+			URL:       o.HTMLURL + "/commit/" + hash,
+			Author:    author,
+			Added:     o.Files,
+		}},
 	}
 }
 

--- a/internal/webhooks/github_test.go
+++ b/internal/webhooks/github_test.go
@@ -578,77 +578,92 @@ func TestGitHubWebhook(t *testing.T) {
 		assert.Equal(t, user.ID, commitUserID)
 	})
 
-	t.Run("same new user commits multiple times", func(t *testing.T) {
-		// Create a user via webhook (by username)
-		payload1 := webhooks.GitHubPushEvent{
+	t.Run("same user commits from different email — matched by username", func(t *testing.T) {
+		// First commit creates a user via the multi-stage lookup:
+		// Stage 1: look up by username (not found)
+		// Stage 3: create user by username, add unverified email identifier
+		firstPayload := webhooks.GitHubPushEvent{
 			Ref: "refs/heads/main",
 			Repository: webhooks.GitHubRepo{
-				ID:       50003,
-				Name:     "multi-repo",
-				FullName: "repmulti/multi-repo",
-				HTMLURL:  "https://github.com/repmulti/multi-repo",
+				ID:       50006,
+				Name:     "first-repo",
+				FullName: "crossemail/first-repo",
+				HTMLURL:  "https://github.com/crossemail/first-repo",
 			},
 			Commits: []webhooks.GitHubCommit{
 				{
-					ID:        "multi-hash-001",
-					Message:   "First commit from repmulti",
+					ID:        "cross-email-001",
+					Message:   "First commit with original email",
 					Timestamp: time.Now(),
-					URL:       "https://github.com/repmulti/multi-repo/commit/abc",
-					Author:    webhooks.GitHubAuthor{Name: "Repmulti", Email: "repmulti@example.com", Username: "repmulti", AvatarURL: "https://example.com/first.png"},
+					URL:       "https://github.com/crossemail/first-repo/commit/abc",
+					Author:    webhooks.GitHubAuthor{Name: "Cross Email", Email: "original@example.com", Username: "crossemail", AvatarURL: "https://example.com/original.png"},
 				},
 			},
 		}
-		resp1 := testutil.PostJSON(t, env, "/api/v1/github", payload1)
-		assert.Equal(t, http.StatusOK, resp1.StatusCode)
+		firstResp := testutil.PostJSON(t, env, "/api/v1/github", firstPayload)
+		assert.Equal(t, http.StatusOK, firstResp.StatusCode)
 
-		var result1 webhooks.ProcessResult
-		require.NoError(t, json.NewDecoder(resp1.Body).Decode(&result1))
-		assert.Equal(t, 1, result1.Created)
+		var firstResult webhooks.ProcessResult
+		require.NoError(t, json.NewDecoder(firstResp.Body).Decode(&firstResult))
+		assert.Equal(t, 1, firstResult.Created)
 
-		// Get the created user
-		user, err := env.Queries.GetUserByUsername(t.Context(), "gh-repmulti")
+		// Find the created user
+		user, err := env.Queries.GetUserByUsername(t.Context(), "gh-crossemail")
 		require.NoError(t, err)
 
-		// Second commit with updated name and avatar
-		payload2 := webhooks.GitHubPushEvent{
+		// Verify user has unverified email identifier (IsPrimary=false)
+		_, err = env.Queries.GetUserIdentifier(t.Context(), "email:original@example.com")
+		require.NoError(t, err)
+		id, err := env.Queries.GetUserIdentifier(t.Context(), "email:original@example.com")
+		require.NoError(t, err)
+		assert.False(t, id.Verified, "email should not be verified from webhook")
+		assert.False(t, id.IsPrimary, "email should not be primary from webhook")
+
+		// Second commit from DIFFERENT email — should still find user by username
+		secondPayload := webhooks.GitHubPushEvent{
 			Ref: "refs/heads/main",
 			Repository: webhooks.GitHubRepo{
-				ID:       50004,
-				Name:     "multi-repo-two",
-				FullName: "repmulti/multi-repo-two",
-				HTMLURL:  "https://github.com/repmulti/multi-repo-two",
+				ID:       50007,
+				Name:     "second-repo",
+				FullName: "crossemail/second-repo",
+				HTMLURL:  "https://github.com/crossemail/second-repo",
 			},
 			Commits: []webhooks.GitHubCommit{
 				{
-					ID:        "multi-hash-002",
-					Message:   "Second commit from repmulti",
+					ID:        "cross-email-002",
+					Message:   "Second commit with different email",
 					Timestamp: time.Now(),
-					URL:       "https://github.com/repmulti/multi-repo-two/commit/def",
-					Author:    webhooks.GitHubAuthor{Name: "Repmulti Updated", Email: "repmulti@example.com", Username: "repmulti", AvatarURL: "https://example.com/second.png"},
+					URL:       "https://github.com/crossemail/second-repo/commit/def",
+					Author:    webhooks.GitHubAuthor{Name: "Cross Email", Email: "other@example.com", Username: "crossemail", AvatarURL: "https://example.com/other.png"},
 				},
 			},
 		}
-		resp2 := testutil.PostJSON(t, env, "/api/v1/github", payload2)
-		assert.Equal(t, http.StatusOK, resp2.StatusCode)
+		secondResp := testutil.PostJSON(t, env, "/api/v1/github", secondPayload)
+		assert.Equal(t, http.StatusOK, secondResp.StatusCode)
 
-		var result2 webhooks.ProcessResult
-		require.NoError(t, json.NewDecoder(resp2.Body).Decode(&result2))
-		assert.Equal(t, 1, result2.Created)
+		var secondResult webhooks.ProcessResult
+		require.NoError(t, json.NewDecoder(secondResp.Body).Decode(&secondResult))
+		assert.Equal(t, 1, secondResult.Created)
 
-		// Verify same user was used (not a duplicate)
-		secondUser, err := env.Queries.GetUserByUsername(t.Context(), "gh-repmulti")
+		// Both commits link to the SAME user (matched by username, not email)
+		commit1, err := env.Queries.GetCommitByHashStr(t.Context(), "cross-email-001")
 		require.NoError(t, err)
-		assert.Equal(t, user.ID, secondUser.ID)
-
-		// User's name stays as original — webhooks don't update user records
-
-		// Verify the second commit links to the same user
-		commit2, err := env.Queries.GetCommitByHashStr(t.Context(), "multi-hash-002")
+		commit2, err := env.Queries.GetCommitByHashStr(t.Context(), "cross-email-002")
 		require.NoError(t, err)
-		require.True(t, commit2.UserID.Valid)
-		commit2UserID, err := uuid.FromBytes(commit2.UserID.Bytes[:])
+
+		commit1ID, err := uuid.FromBytes(commit1.UserID.Bytes[:])
 		require.NoError(t, err)
-		assert.Equal(t, user.ID, commit2UserID)
+		commit2ID, err := uuid.FromBytes(commit2.UserID.Bytes[:])
+		require.NoError(t, err)
+		assert.Equal(t, user.ID, commit1ID)
+		assert.Equal(t, user.ID, commit2ID, "different email commit should link to same user")
+
+		// Original email identifier preserved
+		_, err = env.Queries.GetUserIdentifier(t.Context(), "email:original@example.com")
+		require.NoError(t, err)
+		// New email added as unverified identifier
+		_, err = env.Queries.GetUserIdentifier(t.Context(), "email:other@example.com")
+		require.NoError(t, err)
 	})
 
 	t.Run("empty username no email match: no user association", func(t *testing.T) {


### PR DESCRIPTION
- Add Username/AvatarURL fields to WebhookOpts test helper
- Rename 'same new user commits multiple times' to 'same user commits from different email' — properly tests multi-stage lookup by username with cross-email matching
- Add TestOAuthLoginLinksToWebhookUser — verifies OAuth login finds webhook-created user by username and adds github:<id>
- Add TestOAuthLoginFindsUserByGithubId — verifies OAuth login finds user by github:<id> and updates name/avatar

Closes: #208