### PR TITLE
fix: make leaderboard and home pages responsive on mobile

### DIFF
--- a/internal/features/game/home.templ
+++ b/internal/features/game/home.templ
@@ -29,7 +29,7 @@ templ HomePage(ld layout.LayoutData, data HomeData) {
 templ Hero(game GameStats) {
 	<section class="relative overflow-hidden">
 		<div class="absolute inset-0 bg-gradient-to-b from-purple-900/20 to-transparent"></div>
-		<div class="max-w-7xl mx-auto px-4 py-16 sm:py-24 text-center relative">
+		<div class="max-w-[95vw] sm:max-w-7xl mx-auto px-4 py-12 sm:py-16 md:py-24 text-center relative">
 			<div class="flex justify-center mb-6">
 				<div class="relative text-july-500">
 					@icons.JulythonLogoHero()
@@ -48,7 +48,7 @@ templ Hero(game GameStats) {
 
 templ InfoCards() {
 	<section class="border-y border-white/10 bg-surface-light/50">
-		<div class="max-w-7xl mx-auto px-4 py-12">
+		<div class="max-w-[95vw] sm:max-w-7xl mx-auto px-4 py-8 sm:py-12">
 			<div class="grid md:grid-cols-3 gap-8">
 				@InfoCard("🐍", i18n.T(ctx, "WhatIsTitle"), i18n.T(ctx, "WhatIsBody"))
 				@InfoCard("📋", i18n.T(ctx, "RulesTitle"), i18n.T(ctx, "RulesBody", i18n.M{
@@ -93,7 +93,7 @@ func Unsafe(html string) templ.Component {
 }
 
 templ StatsSection(data HomeData) {
-	<section class="max-w-7xl mx-auto px-4 py-12">
+	<section class="max-w-[95vw] sm:max-w-7xl mx-auto px-4 py-8 sm:py-12">
 		<div class="grid lg:grid-cols-3 gap-8">
 			<div class="lg:col-span-2">
 				<h2 class="text-2xl font-bold text-july-400 mb-6">
@@ -120,7 +120,7 @@ templ CommitHistogram(days []DayCommits, maxCount int) {
 				@HistogramBar(day, maxCount)
 			}
 		</div>
-		<div class="flex justify-between mt-4 text-xs text-gray-500">
+		<div class="flex justify-between mt-4 text-[8px] sm:text-xs text-gray-500">
 			<span>1</span>
 			<span>8</span>
 			<span>15</span>
@@ -166,8 +166,8 @@ templ RecentActivity(commits []RecentCommit) {
 }
 
 templ RecentCommitRow(commit RecentCommit) {
-	<div class="py-3 group">
-		<div class="flex items-start gap-3">
+	<div class="py-2 sm:py-3 group">
+		<div class="flex items-start gap-2 sm:gap-3">
 			@avatar.AvatarFallback(commit.Username, commit.AvatarURL, AvatarSizeSm)
 			<div class="min-w-0 flex-1">
 				<p class="text-sm">

--- a/internal/features/game/home_templ.go
+++ b/internal/features/game/home_templ.go
@@ -110,7 +110,7 @@ func Hero(game GameStats) templ.Component {
 			templ_7745c5c3_Var3 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<section class=\"relative overflow-hidden\"><div class=\"absolute inset-0 bg-gradient-to-b from-purple-900/20 to-transparent\"></div><div class=\"max-w-7xl mx-auto px-4 py-16 sm:py-24 text-center relative\"><div class=\"flex justify-center mb-6\"><div class=\"relative text-july-500\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<section class=\"relative overflow-hidden\"><div class=\"absolute inset-0 bg-gradient-to-b from-purple-900/20 to-transparent\"></div><div class=\"max-w-[95vw] sm:max-w-7xl mx-auto px-4 py-12 sm:py-16 md:py-24 text-center relative\"><div class=\"flex justify-center mb-6\"><div class=\"relative text-july-500\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -160,7 +160,7 @@ func InfoCards() templ.Component {
 			templ_7745c5c3_Var5 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<section class=\"border-y border-white/10 bg-surface-light/50\"><div class=\"max-w-7xl mx-auto px-4 py-12\"><div class=\"grid md:grid-cols-3 gap-8\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<section class=\"border-y border-white/10 bg-surface-light/50\"><div class=\"max-w-[95vw] sm:max-w-7xl mx-auto px-4 py-8 sm:py-12\"><div class=\"grid md:grid-cols-3 gap-8\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -290,7 +290,7 @@ func StatsSection(data HomeData) templ.Component {
 			templ_7745c5c3_Var9 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<section class=\"max-w-7xl mx-auto px-4 py-12\"><div class=\"grid lg:grid-cols-3 gap-8\"><div class=\"lg:col-span-2\"><h2 class=\"text-2xl font-bold text-july-400 mb-6\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<section class=\"max-w-[95vw] sm:max-w-7xl mx-auto px-4 py-8 sm:py-12\"><div class=\"grid lg:grid-cols-3 gap-8\"><div class=\"lg:col-span-2\"><h2 class=\"text-2xl font-bold text-july-400 mb-6\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -384,7 +384,7 @@ func CommitHistogram(days []DayCommits, maxCount int) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "</div><div class=\"flex justify-between mt-4 text-xs text-gray-500\"><span>1</span> <span>8</span> <span>15</span> <span>22</span> <span>31</span></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "</div><div class=\"flex justify-between mt-4 text-[8px] sm:text-xs text-gray-500\"><span>1</span> <span>8</span> <span>15</span> <span>22</span> <span>31</span></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -560,7 +560,7 @@ func RecentCommitRow(commit RecentCommit) templ.Component {
 			templ_7745c5c3_Var21 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "<div class=\"py-3 group\"><div class=\"flex items-start gap-3\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "<div class=\"py-2 sm:py-3 group\"><div class=\"flex items-start gap-2 sm:gap-3\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/features/game/leaderboard.templ
+++ b/internal/features/game/leaderboard.templ
@@ -91,11 +91,11 @@ templ LeaderboardTable(data LeaderboardData) {
 			<table class="w-full">
 				<thead>
 					<tr class="border-b border-white/10 text-gray-400 text-sm">
-						<th class="px-6 py-4 text-left font-medium w-20">{ i18n.T(ctx, "Rank") }</th>
-						<th class="px-6 py-4 text-left font-medium">{ i18n.T(ctx, "Coder") }</th>
-						<th class="px-6 py-4 text-right font-medium">{ i18n.T(ctx, "Commits") }</th>
-						<th class="px-6 py-4 text-right font-medium">{ i18n.T(ctx, "Projects") }</th>
-						<th class="px-6 py-4 text-right font-medium">{ i18n.T(ctx, "Points") }</th>
+						<th class="px-3 py-3 text-left font-medium sm:w-20 sm:px-6 sm:py-4">{ i18n.T(ctx, "Rank") }</th>
+						<th class="px-3 py-3 text-left font-medium sm:px-6 sm:py-4">{ i18n.T(ctx, "Coder") }</th>
+						<th class="hidden px-3 py-3 text-right font-medium sm:table-cell sm:px-6 sm:py-4">{ i18n.T(ctx, "Commits") }</th>
+						<th class="hidden px-3 py-3 text-right font-medium sm:table-cell sm:px-6 sm:py-4">{ i18n.T(ctx, "Projects") }</th>
+						<th class="px-3 py-3 text-right font-medium sm:px-6 sm:py-4">{ i18n.T(ctx, "Points") }</th>
 					</tr>
 				</thead>
 				<tbody>
@@ -122,18 +122,18 @@ templ LeaderboardTable(data LeaderboardData) {
 
 templ LeaderboardRow(entry LeaderboardEntry) {
 	<tr class={ "border-b border-white/5 hover:bg-white/5 transition-colors", templ.KV("bg-july-500/10", entry.Rank <= 3) }>
-		<td class="px-6 py-4">
+		<td class="px-3 py-2 sm:px-6 sm:py-4">
 			@rankCell(entry.Rank)
 		</td>
-		<td class="px-6 py-4">
+		<td class="px-3 py-2 sm:px-6 sm:py-4">
 			<a href={ templ.SafeURL(fmt.Sprintf("/player/%s", entry.Username)) } class="flex items-center gap-3 group">
 				@avatar.AvatarFallback(entry.Username, entry.AvatarURL, avatar.AvatarLg)
 				<span class="font-medium text-white group-hover:text-july-400 transition-colors">{ entry.Name }</span>
 			</a>
 		</td>
-		<td class="px-6 py-4 text-right text-gray-400">{ fmt.Sprintf("%d", entry.CommitCount) }</td>
-		<td class="px-6 py-4 text-right text-gray-400">{ fmt.Sprintf("%d", entry.ProjectCount) }</td>
-		<td class="px-6 py-4 text-right">
+		<td class="hidden px-3 py-2 text-right text-gray-400 sm:table-cell sm:px-6 sm:py-4">{ fmt.Sprintf("%d", entry.CommitCount) }</td>
+		<td class="hidden px-3 py-2 text-right text-gray-400 sm:table-cell sm:px-6 sm:py-4">{ fmt.Sprintf("%d", entry.ProjectCount) }</td>
+		<td class="px-3 py-2 text-right sm:px-6 sm:py-4">
 			<span class="font-bold text-july-400">{ fmt.Sprintf("%d", entry.Points) }</span>
 		</td>
 	</tr>
@@ -165,11 +165,11 @@ templ ProjectLeaderboardTable(data ProjectLeaderboardData) {
 			<table class="w-full">
 				<thead>
 					<tr class="border-b border-white/10 text-gray-400 text-sm">
-						<th class="px-6 py-4 text-left font-medium w-20">{ i18n.T(ctx, "Rank") }</th>
-						<th class="px-6 py-4 text-left font-medium">{ i18n.T(ctx, "Project") }</th>
-						<th class="px-6 py-4 text-right font-medium">{ i18n.T(ctx, "Contributors") }</th>
-						<th class="px-6 py-4 text-right font-medium">{ i18n.T(ctx, "Commits") }</th>
-						<th class="px-6 py-4 text-right font-medium">{ i18n.T(ctx, "Points") }</th>
+						<th class="px-3 py-3 text-left font-medium sm:w-20 sm:px-6 sm:py-4">{ i18n.T(ctx, "Rank") }</th>
+						<th class="px-3 py-3 text-left font-medium sm:px-6 sm:py-4">{ i18n.T(ctx, "Project") }</th>
+						<th class="hidden px-3 py-3 text-right font-medium sm:table-cell sm:px-6 sm:py-4">{ i18n.T(ctx, "Contributors") }</th>
+						<th class="hidden px-3 py-3 text-right font-medium sm:table-cell sm:px-6 sm:py-4">{ i18n.T(ctx, "Commits") }</th>
+						<th class="px-3 py-3 text-right font-medium sm:px-6 sm:py-4">{ i18n.T(ctx, "Points") }</th>
 					</tr>
 				</thead>
 				<tbody>
@@ -189,18 +189,18 @@ templ ProjectLeaderboardTable(data ProjectLeaderboardData) {
 
 templ ProjectLeaderboardRow(entry ProjectLeaderboardEntry) {
 	<tr class={ "border-b border-white/5 hover:bg-white/5 transition-colors", templ.KV("bg-july-500/10", entry.Rank <= 3) }>
-		<td class="px-6 py-4">
+		<td class="px-3 py-2 sm:px-6 sm:py-4">
 			@rankCell(entry.Rank)
 		</td>
-		<td class="px-6 py-4">
+		<td class="px-3 py-2 sm:px-6 sm:py-4">
 			<a href={ templ.SafeURL(fmt.Sprintf("/projects/%s", entry.Slug)) } class="group">
 				<span class="font-medium text-white group-hover:text-july-400 transition-colors">{ entry.ProjectName }</span>
 				<span class="block text-xs text-gray-500">{ entry.Slug }</span>
 			</a>
 		</td>
-		<td class="px-6 py-4 text-right text-gray-400">{ fmt.Sprintf("%d", entry.ContributorCount) }</td>
-		<td class="px-6 py-4 text-right text-gray-400">{ fmt.Sprintf("%d", entry.CommitCount) }</td>
-		<td class="px-6 py-4 text-right">
+		<td class="hidden px-3 py-2 text-right text-gray-400 sm:table-cell sm:px-6 sm:py-4">{ fmt.Sprintf("%d", entry.ContributorCount) }</td>
+		<td class="hidden px-3 py-2 text-right text-gray-400 sm:table-cell sm:px-6 sm:py-4">{ fmt.Sprintf("%d", entry.CommitCount) }</td>
+		<td class="px-3 py-2 text-right sm:px-6 sm:py-4">
 			<span class="font-bold text-july-400">
 				if entry.VerifiedPoints > 0 {
 					{ fmt.Sprintf("%d", entry.VerifiedPoints) }
@@ -238,10 +238,10 @@ templ LanguageLeaderboardTable(data LanguageLeaderboardData) {
 			<table class="w-full">
 				<thead>
 					<tr class="border-b border-white/10 text-gray-400 text-sm">
-						<th class="px-6 py-4 text-left font-medium w-20">{ i18n.T(ctx, "Rank") }</th>
-						<th class="px-6 py-4 text-left font-medium">{ i18n.T(ctx, "Language") }</th>
-						<th class="px-6 py-4 text-right font-medium">{ i18n.T(ctx, "Commits") }</th>
-						<th class="px-6 py-4 text-right font-medium">{ i18n.T(ctx, "Points") }</th>
+						<th class="px-3 py-3 text-left font-medium sm:w-20 sm:px-6 sm:py-4">{ i18n.T(ctx, "Rank") }</th>
+						<th class="px-3 py-3 text-left font-medium sm:px-6 sm:py-4">{ i18n.T(ctx, "Language") }</th>
+						<th class="hidden px-3 py-3 text-right font-medium sm:table-cell sm:px-6 sm:py-4">{ i18n.T(ctx, "Commits") }</th>
+						<th class="px-3 py-3 text-right font-medium sm:px-6 sm:py-4">{ i18n.T(ctx, "Points") }</th>
 					</tr>
 				</thead>
 				<tbody>
@@ -256,14 +256,14 @@ templ LanguageLeaderboardTable(data LanguageLeaderboardData) {
 
 templ LanguageLeaderboardRow(entry LanguageLeaderboardEntry) {
 	<tr class={ "border-b border-white/5 hover:bg-white/5 transition-colors", templ.KV("bg-july-500/10", entry.Rank <= 3) }>
-		<td class="px-6 py-4">
+		<td class="px-3 py-2 sm:px-6 sm:py-4">
 			@rankCell(entry.Rank)
 		</td>
-		<td class="px-6 py-4">
+		<td class="px-3 py-2 sm:px-6 sm:py-4">
 			<span class="font-medium text-white">{ entry.LanguageName }</span>
 		</td>
-		<td class="px-6 py-4 text-right text-gray-400">{ fmt.Sprintf("%d", entry.CommitCount) }</td>
-		<td class="px-6 py-4 text-right">
+		<td class="hidden px-3 py-2 text-right text-gray-400 sm:table-cell sm:px-6 sm:py-4">{ fmt.Sprintf("%d", entry.CommitCount) }</td>
+		<td class="px-3 py-2 text-right sm:px-6 sm:py-4">
 			<span class="font-bold text-july-400">{ fmt.Sprintf("%d", entry.Points) }</span>
 		</td>
 	</tr>

--- a/internal/features/game/leaderboard_templ.go
+++ b/internal/features/game/leaderboard_templ.go
@@ -203,66 +203,66 @@ func LeaderboardTable(data LeaderboardData) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div class=\"bg-surface-light rounded-xl border border-white/10 overflow-hidden\"><table class=\"w-full\"><thead><tr class=\"border-b border-white/10 text-gray-400 text-sm\"><th class=\"px-6 py-4 text-left font-medium w-20\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div class=\"bg-surface-light rounded-xl border border-white/10 overflow-hidden\"><table class=\"w-full\"><thead><tr class=\"border-b border-white/10 text-gray-400 text-sm\"><th class=\"px-3 py-3 text-left font-medium sm:w-20 sm:px-6 sm:py-4\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var7 string
 			templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(i18n.T(ctx, "Rank"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 94, Col: 76}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 94, Col: 96}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</th><th class=\"px-6 py-4 text-left font-medium\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</th><th class=\"px-3 py-3 text-left font-medium sm:px-6 sm:py-4\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var8 string
 			templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(i18n.T(ctx, "Coder"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 95, Col: 72}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 95, Col: 89}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "</th><th class=\"px-6 py-4 text-right font-medium\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "</th><th class=\"hidden px-3 py-3 text-right font-medium sm:table-cell sm:px-6 sm:py-4\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var9 string
 			templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(i18n.T(ctx, "Commits"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 96, Col: 75}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 96, Col: 113}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</th><th class=\"px-6 py-4 text-right font-medium\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</th><th class=\"hidden px-3 py-3 text-right font-medium sm:table-cell sm:px-6 sm:py-4\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var10 string
 			templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(i18n.T(ctx, "Projects"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 97, Col: 76}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 97, Col: 114}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "</th><th class=\"px-6 py-4 text-right font-medium\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "</th><th class=\"px-3 py-3 text-right font-medium sm:px-6 sm:py-4\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var11 string
 			templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(i18n.T(ctx, "Points"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 98, Col: 74}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 98, Col: 91}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 			if templ_7745c5c3_Err != nil {
@@ -358,7 +358,7 @@ func LeaderboardRow(entry LeaderboardEntry) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "\"><td class=\"px-6 py-4\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "\"><td class=\"px-3 py-2 sm:px-6 sm:py-4\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -366,7 +366,7 @@ func LeaderboardRow(entry LeaderboardEntry) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "</td><td class=\"px-6 py-4\"><a href=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "</td><td class=\"px-3 py-2 sm:px-6 sm:py-4\"><a href=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -400,33 +400,33 @@ func LeaderboardRow(entry LeaderboardEntry) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "</span></a></td><td class=\"px-6 py-4 text-right text-gray-400\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "</span></a></td><td class=\"hidden px-3 py-2 text-right text-gray-400 sm:table-cell sm:px-6 sm:py-4\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var19 string
 		templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", entry.CommitCount))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 134, Col: 87}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 134, Col: 124}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "</td><td class=\"px-6 py-4 text-right text-gray-400\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "</td><td class=\"hidden px-3 py-2 text-right text-gray-400 sm:table-cell sm:px-6 sm:py-4\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var20 string
 		templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", entry.ProjectCount))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 135, Col: 88}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 135, Col: 125}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "</td><td class=\"px-6 py-4 text-right\"><span class=\"font-bold text-july-400\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "</td><td class=\"px-3 py-2 text-right sm:px-6 sm:py-4\"><span class=\"font-bold text-july-400\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -566,66 +566,66 @@ func ProjectLeaderboardTable(data ProjectLeaderboardData) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "<div class=\"bg-surface-light rounded-xl border border-white/10 overflow-hidden\"><table class=\"w-full\"><thead><tr class=\"border-b border-white/10 text-gray-400 text-sm\"><th class=\"px-6 py-4 text-left font-medium w-20\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "<div class=\"bg-surface-light rounded-xl border border-white/10 overflow-hidden\"><table class=\"w-full\"><thead><tr class=\"border-b border-white/10 text-gray-400 text-sm\"><th class=\"px-3 py-3 text-left font-medium sm:w-20 sm:px-6 sm:py-4\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var27 string
 			templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs(i18n.T(ctx, "Rank"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 168, Col: 76}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 168, Col: 96}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "</th><th class=\"px-6 py-4 text-left font-medium\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "</th><th class=\"px-3 py-3 text-left font-medium sm:px-6 sm:py-4\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var28 string
 			templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs(i18n.T(ctx, "Project"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 169, Col: 74}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 169, Col: 91}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var28))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "</th><th class=\"px-6 py-4 text-right font-medium\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "</th><th class=\"hidden px-3 py-3 text-right font-medium sm:table-cell sm:px-6 sm:py-4\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var29 string
 			templ_7745c5c3_Var29, templ_7745c5c3_Err = templ.JoinStringErrs(i18n.T(ctx, "Contributors"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 170, Col: 80}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 170, Col: 118}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var29))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "</th><th class=\"px-6 py-4 text-right font-medium\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "</th><th class=\"hidden px-3 py-3 text-right font-medium sm:table-cell sm:px-6 sm:py-4\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var30 string
 			templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.JoinStringErrs(i18n.T(ctx, "Commits"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 171, Col: 75}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 171, Col: 113}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var30))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "</th><th class=\"px-6 py-4 text-right font-medium\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "</th><th class=\"px-3 py-3 text-right font-medium sm:px-6 sm:py-4\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var31 string
 			templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.JoinStringErrs(i18n.T(ctx, "Points"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 172, Col: 74}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 172, Col: 91}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var31))
 			if templ_7745c5c3_Err != nil {
@@ -708,7 +708,7 @@ func ProjectLeaderboardRow(entry ProjectLeaderboardEntry) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "\"><td class=\"px-6 py-4\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "\"><td class=\"px-3 py-2 sm:px-6 sm:py-4\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -716,7 +716,7 @@ func ProjectLeaderboardRow(entry ProjectLeaderboardEntry) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "</td><td class=\"px-6 py-4\"><a href=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "</td><td class=\"px-3 py-2 sm:px-6 sm:py-4\"><a href=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -755,33 +755,33 @@ func ProjectLeaderboardRow(entry ProjectLeaderboardEntry) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "</span></a></td><td class=\"px-6 py-4 text-right text-gray-400\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "</span></a></td><td class=\"hidden px-3 py-2 text-right text-gray-400 sm:table-cell sm:px-6 sm:py-4\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var39 string
 		templ_7745c5c3_Var39, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", entry.ContributorCount))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 201, Col: 92}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 201, Col: 129}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var39))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "</td><td class=\"px-6 py-4 text-right text-gray-400\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "</td><td class=\"hidden px-3 py-2 text-right text-gray-400 sm:table-cell sm:px-6 sm:py-4\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var40 string
 		templ_7745c5c3_Var40, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", entry.CommitCount))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 202, Col: 87}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 202, Col: 124}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var40))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "</td><td class=\"px-6 py-4 text-right\"><span class=\"font-bold text-july-400\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "</td><td class=\"px-3 py-2 text-right sm:px-6 sm:py-4\"><span class=\"font-bold text-july-400\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -933,53 +933,53 @@ func LanguageLeaderboardTable(data LanguageLeaderboardData) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 54, "<div class=\"bg-surface-light rounded-xl border border-white/10 overflow-hidden\"><table class=\"w-full\"><thead><tr class=\"border-b border-white/10 text-gray-400 text-sm\"><th class=\"px-6 py-4 text-left font-medium w-20\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 54, "<div class=\"bg-surface-light rounded-xl border border-white/10 overflow-hidden\"><table class=\"w-full\"><thead><tr class=\"border-b border-white/10 text-gray-400 text-sm\"><th class=\"px-3 py-3 text-left font-medium sm:w-20 sm:px-6 sm:py-4\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var48 string
 			templ_7745c5c3_Var48, templ_7745c5c3_Err = templ.JoinStringErrs(i18n.T(ctx, "Rank"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 241, Col: 76}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 241, Col: 96}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var48))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 55, "</th><th class=\"px-6 py-4 text-left font-medium\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 55, "</th><th class=\"px-3 py-3 text-left font-medium sm:px-6 sm:py-4\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var49 string
 			templ_7745c5c3_Var49, templ_7745c5c3_Err = templ.JoinStringErrs(i18n.T(ctx, "Language"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 242, Col: 75}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 242, Col: 92}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var49))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 56, "</th><th class=\"px-6 py-4 text-right font-medium\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 56, "</th><th class=\"hidden px-3 py-3 text-right font-medium sm:table-cell sm:px-6 sm:py-4\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var50 string
 			templ_7745c5c3_Var50, templ_7745c5c3_Err = templ.JoinStringErrs(i18n.T(ctx, "Commits"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 243, Col: 75}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 243, Col: 113}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var50))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 57, "</th><th class=\"px-6 py-4 text-right font-medium\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 57, "</th><th class=\"px-3 py-3 text-right font-medium sm:px-6 sm:py-4\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var51 string
 			templ_7745c5c3_Var51, templ_7745c5c3_Err = templ.JoinStringErrs(i18n.T(ctx, "Points"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 244, Col: 74}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 244, Col: 91}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var51))
 			if templ_7745c5c3_Err != nil {
@@ -1043,7 +1043,7 @@ func LanguageLeaderboardRow(entry LanguageLeaderboardEntry) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 61, "\"><td class=\"px-6 py-4\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 61, "\"><td class=\"px-3 py-2 sm:px-6 sm:py-4\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1051,7 +1051,7 @@ func LanguageLeaderboardRow(entry LanguageLeaderboardEntry) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 62, "</td><td class=\"px-6 py-4\"><span class=\"font-medium text-white\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 62, "</td><td class=\"px-3 py-2 sm:px-6 sm:py-4\"><span class=\"font-medium text-white\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1064,20 +1064,20 @@ func LanguageLeaderboardRow(entry LanguageLeaderboardEntry) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 63, "</span></td><td class=\"px-6 py-4 text-right text-gray-400\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 63, "</span></td><td class=\"hidden px-3 py-2 text-right text-gray-400 sm:table-cell sm:px-6 sm:py-4\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var56 string
 		templ_7745c5c3_Var56, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", entry.CommitCount))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 265, Col: 87}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/features/game/leaderboard.templ`, Line: 265, Col: 124}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var56))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 64, "</td><td class=\"px-6 py-4 text-right\"><span class=\"font-bold text-july-400\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 64, "</td><td class=\"px-3 py-2 text-right sm:px-6 sm:py-4\"><span class=\"font-bold text-july-400\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
- Hide non-essential columns (Commits, Projects) on mobile in all 3 leaderboards
- Use sm:table-cell to show hidden columns only on desktop
- Reduce table cell padding on mobile (px-3 py-2) with full padding on desktop
- Clamp home page max-width to 95vw on mobile (max-w-7xl on desktop)
- Shrink histogram x-axis labels on mobile (text-[8px] sm:text-xs)
- Tighten recent activity padding/gap on mobile

Closes: #219