### PR TITLE
fix: set session cookie domain for www/non-www compatibility

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -54,6 +54,7 @@ func (d Database) DSN() string {
 
 type Session struct {
 	CookieName      string        `env:"COOKIE_NAME"      envDefault:"july_session"`
+	CookieDomain    string        `env:"COOKIE_DOMAIN"    envDefault:""`
 	Lifetime        time.Duration `env:"LIFETIME"         envDefault:"168h"`
 	CleanupInterval time.Duration `env:"CLEANUP_INTERVAL" envDefault:"15m"`
 }
@@ -121,6 +122,7 @@ func (c Config) Log() {
 		Int("database.min_conns", c.Database.MinConns).
 		// Session
 		Str("session.cookie_name", c.Session.CookieName).
+		Str("session.cookie_domain", c.Session.CookieDomain).
 		Dur("session.lifetime", c.Session.Lifetime).
 		Dur("session.cleanup_interval", c.Session.CleanupInterval).
 		// OAuth

--- a/internal/services/session.go
+++ b/internal/services/session.go
@@ -29,6 +29,9 @@ func NewSessionManager(pool *pgxpool.Pool, cfg config.Session, isProd bool) *Ses
 	sm.Cookie.HttpOnly = true
 	sm.Cookie.Secure = isProd
 	sm.Cookie.SameSite = http.SameSiteLaxMode
+	if cfg.CookieDomain != "" {
+		sm.Cookie.Domain = cfg.CookieDomain
+	}
 
 	return &SessionManager{
 		SessionManager: sm,

--- a/internal/services/session_test.go
+++ b/internal/services/session_test.go
@@ -1,0 +1,42 @@
+package services_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"july/internal/config"
+	"july/internal/testutil"
+)
+
+func TestSessionCookieDomain(t *testing.T) {
+	env := testutil.SetupTestEnv(t)
+
+	t.Run("production sets cookie domain", func(t *testing.T) {
+		prodCfg := config.Session{
+			CookieName:   "july_session",
+			CookieDomain: ".julython.org",
+		}
+		sm := testutil.NewTestSessionManager(t, env.Pool, prodCfg, true)
+		assert.Equal(t, ".julython.org", sm.Cookie.Domain, "cookie domain should be set in production")
+		assert.True(t, sm.Cookie.Secure, "cookie should be Secure in production")
+	})
+
+	t.Run("development leaves domain empty", func(t *testing.T) {
+		devCfg := config.Session{
+			CookieName: "july_session",
+		}
+		sm := testutil.NewTestSessionManager(t, env.Pool, devCfg, false)
+		assert.Equal(t, "", sm.Cookie.Domain, "cookie domain should be empty in development")
+		assert.False(t, sm.Cookie.Secure, "cookie should not be Secure in development")
+	})
+
+	t.Run("production with empty domain leaves it blank", func(t *testing.T) {
+		emptyCfg := config.Session{
+			CookieName: "july_session",
+		}
+		sm := testutil.NewTestSessionManager(t, env.Pool, emptyCfg, true)
+		assert.Equal(t, "", sm.Cookie.Domain, "empty domain should not be set even in production")
+		assert.True(t, sm.Cookie.Secure, "cookie should be Secure in production")
+	})
+}

--- a/internal/testutil/db.go
+++ b/internal/testutil/db.go
@@ -163,6 +163,13 @@ func SetupTestEnv(t *testing.T) *TestEnv {
 	}
 }
 
+// NewTestSessionManager creates a SessionManager with the given config.
+// Exported so test packages can construct sessions without a full test server.
+func NewTestSessionManager(t *testing.T, pool *pgxpool.Pool, cfg config.Session, isProd bool) *services.SessionManager {
+	t.Helper()
+	return services.NewSessionManager(pool, cfg, isProd)
+}
+
 func ensureSystemUser(ctx context.Context, pool *pgxpool.Pool) error {
 	_, err := pool.Exec(ctx, `
 		INSERT INTO users (id, name, username, role)


### PR DESCRIPTION
- Add CookieDomain field to Session config (JULY_SESSION_COOKIE_DOMAIN)
- Set cookie Domain in NewSessionManager when configured
- Log cookie_domain in config output
- Add session tests verifying domain behavior in prod vs dev

Closes: #228