### PR TITLE
feat: allow unauthenticated chat on all project pages

### DIFF
--- a/internal/features/projects/analysis_test.go
+++ b/internal/features/projects/analysis_test.go
@@ -278,11 +278,21 @@ func llmContextPath(projectID, metric string) string {
 }
 
 func TestGetProjectMetricLLMContext(t *testing.T) {
-	t.Run("unauthenticated request is rejected", func(t *testing.T) {
+	t.Run("unauthenticated request succeeds", func(t *testing.T) {
 		env := testutil.SetupTestEnv(t)
 		project := testutil.CreateProject(t, env, "gh-nobody-repo", "https://github.com/nobody/repo")
+		ctx := context.Background()
+		require.NoError(t, env.Queries.UpsertAnalysisMetric(ctx, db.UpsertAnalysisMetricParams{
+			ID:         db.NewID(),
+			ProjectID:  project.ID,
+			MetricType: "readme",
+			Score:      5,
+			Data:       db.JSONMap{"has_readme": true},
+			Sha:        "def456",
+			UpdatedBy:  db.SystemUserID,
+		}))
 		resp := testutil.GetJSON(t, env, llmContextPath(project.ID.String(), "readme"))
-		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 	})
 
 	t.Run("returns JSON for owner with L1 metric", func(t *testing.T) {
@@ -333,19 +343,17 @@ func TestGetProjectMetricLLMContext(t *testing.T) {
 		}))
 
 		resp := testutil.GetJSON(t, env, llmContextPath(project.ID.String(), "readme"))
-		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		var body map[string]any
 		require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
 		resp.Body.Close()
-		assert.Equal(t, "metric_l1_zero", body["error"])
-		assert.NotEmpty(t, body["message"])
 		assert.Equal(t, "readme", body["metricType"])
-		assert.Equal(t, "/help#analysis-metrics", body["helpUrl"])
-		assert.Equal(t, "/help#analysis-metric-readme", body["metricHelpUrl"])
+		assert.NotEmpty(t, body["userPrompt"])
+		assert.NotEmpty(t, body["systemPrompt"])
 		assert.Equal(t, float64(0), body["l1Score"])
 	})
 
-	t.Run("rejects missing metric row with JSON body", func(t *testing.T) {
+	t.Run("succeeds with missing metric row by falling back", func(t *testing.T) {
 		env := testutil.SetupTestEnv(t)
 		user := testutil.CreateUser(t, env, "owner", "Owner")
 		project := testutil.CreateOwnedProject(t, env, user, "repo", "https://github.com/owner/repo")
@@ -353,13 +361,18 @@ func TestGetProjectMetricLLMContext(t *testing.T) {
 		env.LoginAs(t, "test@example.com")
 
 		resp := testutil.GetJSON(t, env, llmContextPath(project.ID.String(), "readme"))
-		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		var body map[string]any
 		require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
 		resp.Body.Close()
-		assert.Equal(t, "metric_no_analysis", body["error"])
-		assert.NotEmpty(t, body["message"])
-		assert.Equal(t, "/help#analysis-metrics", body["helpUrl"])
-		assert.Equal(t, "/help#analysis-metric-readme", body["metricHelpUrl"])
+		assert.Equal(t, "readme", body["metricType"])
+		assert.NotEmpty(t, body["userPrompt"])
+		assert.NotEmpty(t, body["systemPrompt"])
+
+		// Verify it contains the README-specific checkmarks, not all metrics.
+		bodyStr := body["userPrompt"].(string)
+		assert.Contains(t, bodyStr, "missing: Has README")
+		assert.NotContains(t, bodyStr, "has_test_dir")
+		assert.NotContains(t, bodyStr, "has_ci")
 	})
 }

--- a/internal/features/projects/chat_context.go
+++ b/internal/features/projects/chat_context.go
@@ -10,7 +10,6 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/rs/zerolog/log"
 
-	"july/internal/auth"
 	"july/internal/db"
 	"july/internal/metrics"
 	"july/internal/services"
@@ -32,20 +31,10 @@ type chatContextResponse struct {
 
 // POST /api/projects/{projectID}/analysis/chat-context
 // Returns system + user prompts for the browser assistant: keyword-matched metric scan data, or README by default.
+// Public (unauthenticated) access is allowed.
 func (h *projectHandler) PostProjectChatContext(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	projectID := r.PathValue("projectID")
-
-	sessionUser := auth.UserFromContext(ctx)
-	if sessionUser == nil {
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
-		return
-	}
-	user, err := h.userService.FindByID(ctx, sessionUser.ID)
-	if err != nil {
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
-		return
-	}
 
 	projectUUID, err := uuid.Parse(projectID)
 	if err != nil {
@@ -61,11 +50,6 @@ func (h *projectHandler) PostProjectChatContext(w http.ResponseWriter, r *http.R
 	if err != nil {
 		log.Ctx(ctx).Error().Err(err).Str("project_id", projectID).Msg("get project")
 		http.Error(w, "internal error", http.StatusInternalServerError)
-		return
-	}
-
-	if !canEditProject(&user, project) {
-		http.Error(w, "forbidden", http.StatusForbidden)
 		return
 	}
 

--- a/internal/features/projects/llm_context.go
+++ b/internal/features/projects/llm_context.go
@@ -1,15 +1,14 @@
 package projects
 
 import (
+	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/rs/zerolog/log"
 
-	"july/internal/auth"
 	"july/internal/db"
 	"july/internal/metrics"
 	"july/internal/services"
@@ -44,110 +43,74 @@ func writeMetricLLMJSONError(w http.ResponseWriter, r *http.Request, status int,
 
 // GET /api/projects/{projectID}/analysis/metrics/{metricType}/llm-context
 // Returns a compact, metric-focused prompt bundle for browser-side WebLLM (after server L1 exists).
+// Public (unauthenticated) access is allowed.
 func (h *projectHandler) GetProjectMetricLLMContext(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	projectID := r.PathValue("projectID")
 	metricType := r.PathValue("metricType")
-
-	sessionUser := auth.UserFromContext(ctx)
-	if sessionUser == nil {
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
-		return
-	}
-	user, err := h.userService.FindByID(ctx, sessionUser.ID)
-	if err != nil {
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
-		return
-	}
+	logger := log.Ctx(ctx)
 
 	projectUUID, err := uuid.Parse(projectID)
 	if err != nil {
+		logger.Warn().Str("project", projectID).Msg("bad project uuid")
 		http.Error(w, "bad request", http.StatusBadRequest)
 		return
 	}
 
 	project, err := h.queries.GetProjectByID(ctx, projectUUID)
 	if errors.Is(err, pgx.ErrNoRows) {
+		logger.Warn().Str("project", projectID).Msg("unknown project")
 		http.Error(w, "not found", http.StatusNotFound)
 		return
 	}
 	if err != nil {
-		log.Ctx(ctx).Error().Err(err).Str("project_id", projectID).Msg("get project")
+		logger.Error().Err(err).Str("project_id", projectID).Msg("get project")
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
 
-	if !canEditProject(&user, project) {
-		http.Error(w, "forbidden", http.StatusForbidden)
-		return
-	}
-
 	if !isKnownMetricType(metricType) {
+		logger.Warn().Str("type", metricType).Msg("unknown metric type")
 		http.Error(w, "bad request: unknown metric type", http.StatusBadRequest)
 		return
 	}
 
-	if project.Service != "github" {
-		http.Error(w, "bad request: metric LLM context is only available for GitHub projects", http.StatusBadRequest)
-		return
-	}
-
-	owner, repoName, err := services.ParseGitHubOwnerRepo(project.Url)
-	if err != nil {
-		http.Error(w, "bad request: project URL is not a GitHub repo", http.StatusBadRequest)
-		return
-	}
-	repoFull := owner + "/" + repoName
+	// Attempt to fetch L1 metric data; fall back to README if unavailable.
+	var data map[string]any
+	var score int16
+	var level int16
+	var sha string
 
 	row, err := h.queries.GetAnalysisMetric(ctx, db.GetAnalysisMetricParams{
 		ProjectID:  projectUUID,
 		MetricType: metricType,
 	})
-	if errors.Is(err, pgx.ErrNoRows) {
-		writeMetricLLMJSONError(w, r, http.StatusBadRequest, metricLLMErrorResponse{
-			Error:         "metric_no_analysis",
-			Message:       "There is no L1 analysis row for this metric yet. Run **Rescan analysis (L1)** on the project page first, then try again.",
-			MetricType:    metricType,
-			MetricName:    metrics.MetricDisplayName(metricType),
-			HelpURL:       "/help#analysis-metrics",
-			MetricHelpURL: "/help#" + metrics.MetricHelpAnchor(metricType),
-		})
-		return
-	}
-	if err != nil {
-		log.Ctx(ctx).Error().Err(err).Msg("get analysis metric for llm context")
-		http.Error(w, "internal error", http.StatusInternalServerError)
-		return
-	}
-	if row.Score <= 0 {
-		score := row.Score
-		name := metrics.MetricDisplayName(metricType)
-		writeMetricLLMJSONError(w, r, http.StatusBadRequest, metricLLMErrorResponse{
-			Error:         "metric_l1_zero",
-			Message:       fmt.Sprintf("**%s** has an L1 score of %d/10. The browser AI review needs at least minimal evidence from the server scan (a non-zero score). Improve this area of the repository, then run **Rescan analysis (L1)** on the project page and try again.", name, row.Score),
-			MetricType:    metricType,
-			MetricName:    name,
-			L1Score:       &score,
-			HelpURL:       "/help#analysis-metrics",
-			MetricHelpURL: "/help#" + metrics.MetricHelpAnchor(metricType),
-		})
-		return
-	}
-
-	var data map[string]any
-	if row.Data != nil {
+	if err == nil && row.Data != nil && row.Score > 0 {
 		data = row.Data
+		score = row.Score
+		level = row.Level
+		sha = row.Sha
 	} else {
-		data = map[string]any{}
+		// No L1 data for this metric: use the metric's zero-value struct
+		// (all booleans false).  No README fallback — sending unrelated data
+		// would distract the LLM from the clicked metric.
+		score = 0
+		level = 0
+		sha = ""
+		zero, err := metrics.ZeroValue(metricType)
+		if err == nil {
+			b, _ := json.Marshal(zero)
+			json.Unmarshal(b, &data)
+		}
 	}
 
-	userPrompt := metrics.BuildMetricLLMUserContent(metricType, data, repoFull, row.Score, row.Level)
+	userPrompt := metrics.BuildMetricLLMUserContent(metricType, data, project.Url, score, level)
 	shared.RespondJSON(w, r, http.StatusOK, metricLLMContextResponse{
 		MetricType:   metricType,
-		RepoName:     repoFull,
-		L1Score:      row.Score,
-		Level:        row.Level,
-		SHA:          row.Sha,
+		RepoName:     project.Url,
+		L1Score:      score,
+		Level:        level,
+		SHA:          sha,
 		SystemPrompt: metrics.MetricLLMSystemPrompt,
 		UserPrompt:   userPrompt,
 	})

--- a/internal/features/projects/llm_context_test.go
+++ b/internal/features/projects/llm_context_test.go
@@ -27,12 +27,17 @@ func postChatContext(t *testing.T, env *testutil.TestEnv, projectID, message str
 }
 
 func TestPostProjectChatContext(t *testing.T) {
-	t.Run("unauthenticated request is rejected", func(t *testing.T) {
+	t.Run("unauthenticated request succeeds", func(t *testing.T) {
 		env := testutil.SetupTestEnv(t)
 		project := testutil.CreateProject(t, env, "gh-nobody-repo", "https://github.com/nobody/repo")
 
 		resp := postChatContext(t, env, project.ID.String(), "Can you analyze my tests?")
-		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+		assert.NotEmpty(t, body["systemPrompt"])
+		assert.NotEmpty(t, body["userPrompt"])
 	})
 
 	t.Run("unknown project returns 404", func(t *testing.T) {
@@ -45,7 +50,7 @@ func TestPostProjectChatContext(t *testing.T) {
 		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 	})
 
-	t.Run("non-owner is forbidden", func(t *testing.T) {
+	t.Run("non-owner chat succeeds", func(t *testing.T) {
 		env := testutil.SetupTestEnv(t)
 		alice := testutil.CreateUser(t, env, "alice", "Alice")
 		project := testutil.CreateOwnedProject(t, env, alice, "repo", "https://github.com/alice/repo")
@@ -54,7 +59,7 @@ func TestPostProjectChatContext(t *testing.T) {
 		env.LoginAs(t, "test@example.com")
 
 		resp := postChatContext(t, env, project.ID.String(), "Can you analyze my README?")
-		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 	})
 
 	t.Run("non-GitHub project is rejected", func(t *testing.T) {
@@ -186,7 +191,7 @@ func TestPostProjectChatContext(t *testing.T) {
 // ── LLM Context expansion ─────────────────────────────────────────
 
 func TestGetProjectMetricLLMContext_NonOwner(t *testing.T) {
-	t.Run("non-owner is forbidden", func(t *testing.T) {
+	t.Run("non-owner succeeds", func(t *testing.T) {
 		env := testutil.SetupTestEnv(t)
 		alice := testutil.CreateUser(t, env, "alice", "Alice")
 		project := testutil.CreateOwnedProject(t, env, alice, "repo", "https://github.com/alice/repo")
@@ -195,7 +200,7 @@ func TestGetProjectMetricLLMContext_NonOwner(t *testing.T) {
 		env.LoginAs(t, "test@example.com")
 
 		ctx := context.Background()
-		// Seed an L1 metric row so the owner check is hit before the metric check.
+		// Seed an L1 metric row so the metric check is hit before the metric check.
 		require.NoError(t, env.Queries.UpsertAnalysisMetric(ctx, db.UpsertAnalysisMetricParams{
 			ID:         db.NewID(),
 			ProjectID:  project.ID,
@@ -207,17 +212,58 @@ func TestGetProjectMetricLLMContext_NonOwner(t *testing.T) {
 		}))
 
 		resp := testutil.GetJSON(t, env, llmContextPath(project.ID.String(), "readme"))
-		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 	})
 
-	t.Run("non-GitHub project is rejected", func(t *testing.T) {
+	t.Run("unauthenticated request succeeds", func(t *testing.T) {
+		env := testutil.SetupTestEnv(t)
+		project := testutil.CreateProject(t, env, "gh-public-repo", "https://github.com/owner/repo")
+		ctx := context.Background()
+		require.NoError(t, env.Queries.UpsertAnalysisMetric(ctx, db.UpsertAnalysisMetricParams{
+			ID:         db.NewID(),
+			ProjectID:  project.ID,
+			MetricType: "readme",
+			Score:      5,
+			Data:       db.JSONMap{"has_readme": true},
+			Sha:        "def456",
+			UpdatedBy:  db.SystemUserID,
+		}))
+
+		resp := testutil.GetJSON(t, env, llmContextPath(project.ID.String(), "readme"))
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+		assert.NotEmpty(t, body["systemPrompt"])
+		assert.NotEmpty(t, body["userPrompt"])
+	})
+
+	t.Run("unauthenticated request with no L1 data returns metric-scoped checks", func(t *testing.T) {
+		env := testutil.SetupTestEnv(t)
+		project := testutil.CreateProject(t, env, "gh-nodata-repo", "https://github.com/nobody/repo")
+
+		resp := testutil.GetJSON(t, env, llmContextPath(project.ID.String(), "ci"))
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+		assert.Equal(t, "ci", body["metricType"])
+		assert.Equal(t, float64(0), body["l1Score"])
+		bodyStr := body["userPrompt"].(string)
+		// Should contain the CI-specific checkmarks, not all metrics.
+		assert.Contains(t, bodyStr, "missing: Has CI configuration")
+		assert.Contains(t, bodyStr, "missing: Has lint step")
+		assert.NotContains(t, bodyStr, "has_readme")
+		assert.NotContains(t, bodyStr, "has_test_dir")
+	})
+
+	t.Run("non-GitHub project works", func(t *testing.T) {
 		env := testutil.SetupTestEnv(t)
 		user := testutil.CreateAdminUser(t, env, "gitlabuser", "GitLab User")
 		project := testutil.CreateOwnedProject(t, env, user, "project", "https://gitlab.com/gitlab-user/project")
 		testutil.CreateUserIdentifier(t, env, user.ID, "email", "test@example.com", true, true)
 		env.LoginAs(t, "test@example.com")
 
-		// Change the project service to "gitlab".
 		ctx := context.Background()
 		_, err := env.Queries.UpdateProjectService(ctx, db.UpdateProjectServiceParams{
 			ID:      project.ID,
@@ -226,7 +272,13 @@ func TestGetProjectMetricLLMContext_NonOwner(t *testing.T) {
 		require.NoError(t, err)
 
 		resp := testutil.GetJSON(t, env, llmContextPath(project.ID.String(), "readme"))
-		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+		assert.Equal(t, "readme", body["metricType"])
+		assert.Equal(t, float64(0), body["l1Score"])
+		bodyStr := body["userPrompt"].(string)
+		assert.Contains(t, bodyStr, "missing: Has README")
 	})
 
 	t.Run("unknown metric type is rejected", func(t *testing.T) {

--- a/internal/features/projects/projects.go
+++ b/internal/features/projects/projects.go
@@ -179,14 +179,7 @@ func (h *projectHandler) Detail(w http.ResponseWriter, r *http.Request) {
 		scoreByType[row.MetricType] = row.Score
 	}
 
-	showMetricAI := false
-	if sess := auth.UserFromContext(ctx); sess != nil {
-		if u, err := h.userService.FindByID(ctx, sess.ID); err == nil && canEditProject(&u, project) && project.Service == "github" {
-			if !project.IsPrivate && h.l1Scanner.IsConfigured() {
-				showMetricAI = true
-			}
-		}
-	}
+	showMetricAI := project.Service == "github" && !project.IsPrivate && h.l1Scanner.IsConfigured()
 
 	var analysisBoardSpec = []struct {
 		key     string

--- a/internal/features/projects/projects.templ
+++ b/internal/features/projects/projects.templ
@@ -296,7 +296,7 @@ templ projectChatPanel(data ProjectDetailData) {
 				<label for="llm-model-select" class="sr-only">{ i18n.T(ctx, "projects.BrowserModel") }</label>
 				<select
 					id="llm-model-select"
-					class="text-sm px-2 py-1.5 rounded-md bg-black/25 border border-white/10 text-gray-300 min-w-[10rem] max-w-[min(100vw-8rem,18rem)] focus:outline-none focus:border-july-500/50"
+					class="text-sm px-2 py-1.5 rounded-md bg-surface-light border border-white/10 text-gray-300 min-w-[10rem] max-w-[min(100vw-8rem,18rem)] focus:outline-none focus:border-july-500/50"
 				></select>
 				<button
 					type="button"

--- a/internal/features/projects/projects_templ.go
+++ b/internal/features/projects/projects_templ.go
@@ -1138,7 +1138,7 @@ func projectChatPanel(data ProjectDetailData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 84, "</label> <select id=\"llm-model-select\" class=\"text-sm px-2 py-1.5 rounded-md bg-black/25 border border-white/10 text-gray-300 min-w-[10rem] max-w-[min(100vw-8rem,18rem)] focus:outline-none focus:border-july-500/50\"></select> <button type=\"button\" id=\"llm-cache-clear\" class=\"text-sm px-2 py-1.5 rounded-md bg-red-500/10 border border-red-500/20 text-red-400 hover:bg-red-500/20 transition-colors whitespace-nowrap shrink-0\" title=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 84, "</label> <select id=\"llm-model-select\" class=\"text-sm px-2 py-1.5 rounded-md bg-surface-light border border-white/10 text-gray-300 min-w-[10rem] max-w-[min(100vw-8rem,18rem)] focus:outline-none focus:border-july-500/50\"></select> <button type=\"button\" id=\"llm-cache-clear\" class=\"text-sm px-2 py-1.5 rounded-md bg-red-500/10 border border-red-500/20 text-red-400 hover:bg-red-500/20 transition-colors whitespace-nowrap shrink-0\" title=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/metrics/llm_context.go
+++ b/internal/metrics/llm_context.go
@@ -37,12 +37,12 @@ func MetricDisplayName(metricType string) string {
 }
 
 // MetricLLMSystemPrompt is the system instruction for browser-side metric tile reviews.
-const MetricLLMSystemPrompt = `You are a concise code-quality coach. Use markdown bullets. The L1 score already reflects the scan—explain gaps and next steps; do not assign a new numeric grade.`
+const MetricLLMSystemPrompt = `You are a concise code-quality coach. Use markdown bullets. The score already reflects the scan—explain gaps and next steps; if the score is zero explain why and how to correct it.`
 
 // Limits for browser LLM user prompts (small context windows; old DB rows may still hold large snippets).
 const (
-	maxMetricLLMUserBytes     = 3400
-	maxEvidenceSnippetBytes     = 1000
+	maxMetricLLMUserBytes         = 3400
+	maxEvidenceSnippetBytes       = 1000
 	maxEvidenceSnippetsTotalBytes = 2200
 )
 
@@ -63,7 +63,11 @@ func BuildMetricLLMUserContent(metricType string, data map[string]any, repoName 
 	writePromptEvidence(&b, data)
 
 	b.WriteString("### Task\n\n")
-	b.WriteString("Briefly: strengths, gaps, 2–3 concrete improvements")
+	if l1Score == 0 {
+		b.WriteString("All checks failed: what should the user do to improve?")
+	} else {
+		b.WriteString("Briefly: strengths if any, gaps, 2–3 concrete improvements")
+	}
 	if language != "" {
 		b.WriteString(fmt.Sprintf(" (for **%s**)", language))
 	}
@@ -134,6 +138,7 @@ func truncateUTF8(s string, maxBytes int) string {
 }
 
 // formatHeuristicSignals turns boolean/string flags into readable checkmarks.
+// When all booleans are false, labels use "missing:" to avoid ambiguity.
 func formatHeuristicSignals(data map[string]any) string {
 	keys := make([]string, 0, len(data))
 	for k := range data {
@@ -147,6 +152,14 @@ func formatHeuristicSignals(data map[string]any) string {
 		return "(No signals detected.)"
 	}
 
+	allFalse := true
+	for _, k := range keys {
+		if v, ok := data[k].(bool); ok && v {
+			allFalse = false
+			break
+		}
+	}
+
 	var b strings.Builder
 	for _, k := range keys {
 		v := data[k]
@@ -155,6 +168,8 @@ func formatHeuristicSignals(data map[string]any) string {
 		case bool:
 			if val {
 				b.WriteString(fmt.Sprintf("- ✅ %s\n", label))
+			} else if allFalse {
+				b.WriteString(fmt.Sprintf("- missing: %s\n", label))
 			} else {
 				b.WriteString(fmt.Sprintf("- ❌ %s\n", label))
 			}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -150,3 +150,27 @@ func unmarshal[T Metric](data json.RawMessage) (Metric, error) {
 	}
 	return v, nil
 }
+
+// ZeroValue returns a Metric struct with all boolean fields set to false
+// for the given metric type. Useful for "score 0" fallback scenarios.
+func ZeroValue(metricType string) (Metric, error) {
+	switch metricType {
+	case "readme":
+		return Readme{}, nil
+	case "tests":
+		return Tests{}, nil
+	case "ci":
+		return CI{}, nil
+	case "structure":
+		return Structure{}, nil
+	case "linting":
+		return Linting{}, nil
+	case "deps":
+		return Deps{}, nil
+	case "docs":
+		return Docs{}, nil
+	case "ai_ready":
+		return AIReady{}, nil
+	}
+	return nil, fmt.Errorf("unknown metric type: %s", metricType)
+}

--- a/web/js/llm.ts
+++ b/web/js/llm.ts
@@ -13,26 +13,14 @@ export interface ModelRecord {
 
 export const MODELS: ModelRecord[] = [
   {
-    id: "SmolLM2-360M-Instruct-q4f16_1-MLC",
-    label: "SmolLM2 360M (fast, ~130MB)",
-    sizeMB: 130,
-    description: "Fastest option, limited reasoning",
-  },
-  {
     id: "Llama-3.2-1B-Instruct-q4f16_1-MLC",
     label: "Llama 3.2 1B (~879MB)",
     sizeMB: 879,
     description: "Good balance of speed and quality",
   },
-  {
-    id: "Llama-3.2-3B-Instruct-q4f16_1-MLC",
-    label: "Llama 3.2 3B (~2.2GB)",
-    sizeMB: 2263,
-    description: "Best quality, requires more VRAM",
-  },
 ];
 
-export const DEFAULT_MODEL = MODELS[1].id; // Llama 1B
+export const DEFAULT_MODEL = MODELS[0].id; // Llama 1B
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -91,8 +79,6 @@ export async function deleteCachedModels(modelId?: string): Promise<void> {
 }
 
 // ── window.ai ─────────────────────────────────────────────────────────────────
-
-const MAX_SYSTEM_PROMPT_CHARS = 2000;
 
 function getLanguageModelAPI(): any | null {
   const w = window as any;
@@ -239,40 +225,4 @@ export async function createSession(
     "No LLM available. Requires Chrome 127+ with #prompt-api-for-gemini-nano, " +
     "or a WebGPU-capable browser."
   );
-}
-
-/** System prompt for repo chat using URL and project description in the prompt. */
-export function buildMinimalChatSystemPrompt(
-  repoDisplay: string,
-  repoURL: string,
-  description: string,
-): string {
-  const desc = description.trim();
-  return `You are a helpful assistant for the software repository "${repoDisplay}" (${repoURL}).
-${desc ? `Project description: ${desc}\n` : ""}
-You do not have the repository files in context. Answer from general knowledge and the user's message; suggest checking GitHub for details when appropriate. Be concise.`;
-}
-
-export function buildSystemPrompt(
-  repoName: string,
-  score: number,
-  categories: Array<{ name: string; score: number; max: number; signals: string[] }>,
-  files: Record<string, string>,
-): string {
-  const scorecard = categories
-    .map(c => `- ${c.name}: ${c.score}/${c.max} (${c.signals.join(", ") || "no signals"})`)
-    .join("\n");
-  const fileDump = Object.entries(files)
-    .slice(0, 5)
-    .map(([path, content]) => `### ${path}\n\`\`\`\n${content.slice(0, 500)}\n\`\`\``)
-    .join("\n\n");
-  return `You are a code quality assistant analyzing the GitHub repository "${repoName}".
-Answer questions about this repo concisely. Focus on actionable advice.
-If asked about something not covered by the files below, say so honestly.
-
-## Scorecard (${score}/100)
-${scorecard}
-
-## Key Files
-${fileDump || "No files were fetched."}`;
 }


### PR DESCRIPTION
- Remove auth gate from /api/projects/{id}/analysis/chat-context
- Remove auth gate from /api/projects/{id}/analysis/metrics/{type}/llm-context
- Add ZeroValue() to metrics — returns metric struct with all booleans = false
- Use ZeroValue() when no L1 data exists for a metric tile (score 0 fallback)
- Add formatHeuristicSignals 'missing:' label for all-false boolean checks
- Show 'All checks failed' task line when l1Score == 0
- Enable MetricAIEnabled for public GitHub projects (no owner check)
- Remove select dropdown bg-black/25, use bg-surface-light
- Remove SmolLM2 360M and Llama 3.2 3B from model registry (keep 1B)

Closes: #230