### PR TITLE
feat: refresh player verified_points after L1 scan

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -39,7 +39,7 @@ func buildMux(pool *pgxpool.Pool, cfg *config.Config) (
 	queries := db.New(pool)
 	userSvc := services.MustNewUserService(queries, cfg.Database.EncKey)
 	gameSvc := services.NewGameService(queries)
-	scanner := metrics.NewScanner(queries, pool, cfg.GitHubToken)
+	scanner := metrics.NewScanner(queries, pool, gameSvc, cfg.GitHubToken)
 
 	// OAuth providers
 	providers := make(map[string]services.OAuthProvider)

--- a/internal/db/player_boards_test.go
+++ b/internal/db/player_boards_test.go
@@ -316,6 +316,13 @@ func TestListPlayersWithBoards(t *testing.T) {
 			PlayerID: player.ID,
 		})
 		require.NoError(t, err)
+		// Set player's verified_points to match (mimics assignPlayerBoards).
+		err = env.Queries.UpdatePlayerAnalysis(ctx, db.UpdatePlayerAnalysisParams{
+			ID:             player.ID,
+			VerifiedPoints: 10,
+			AnalysisStatus: "complete",
+		})
+		require.NoError(t, err)
 
 		// Assign board (score=50) to player2
 		_, err = env.Queries.AssignBoards(ctx, db.AssignBoardsParams{
@@ -323,10 +330,16 @@ func TestListPlayersWithBoards(t *testing.T) {
 			PlayerID: player2.ID,
 		})
 		require.NoError(t, err)
+		err = env.Queries.UpdatePlayerAnalysis(ctx, db.UpdatePlayerAnalysisParams{
+			ID:             player2.ID,
+			VerifiedPoints: 50,
+			AnalysisStatus: "complete",
+		})
+		require.NoError(t, err)
 
 		rows, err := env.Queries.GetLeaderboard(ctx, db.GetLeaderboardParams{
 			GameID:     game.ID,
-			LimitCount: 100,
+			Limit: 100,
 		})
 		require.NoError(t, err)
 		require.Len(t, rows, 2)
@@ -349,16 +362,16 @@ func TestListPlayersWithBoards(t *testing.T) {
 	t.Run("players with no boards get total 0", func(t *testing.T) {
 		rows, err := env.Queries.GetLeaderboard(ctx, db.GetLeaderboardParams{
 			GameID:     game.ID,
-			LimitCount: 100,
+			Limit: 100,
 		})
 		require.NoError(t, err)
 		require.Len(t, rows, 2)
 
 		for _, r := range rows {
 			if r.ID == player.ID {
-				assertBoardTotalEqual(t, 10, r.BoardTotal)
+				verifiedPoints(t, 10, r)
 			} else {
-				assertBoardTotalEqual(t, 50, r.BoardTotal)
+				verifiedPoints(t, 50, r)
 			}
 		}
 	})
@@ -384,9 +397,17 @@ func TestListPlayersWithBoards(t *testing.T) {
 		})
 		require.NoError(t, err)
 
+		// Set verified_points to sum of 3 boards (10+50+20=80).
+		err = env.Queries.UpdatePlayerAnalysis(ctx, db.UpdatePlayerAnalysisParams{
+			ID:             player.ID,
+			VerifiedPoints: 80,
+			AnalysisStatus: "complete",
+		})
+		require.NoError(t, err)
+
 		rows, err := env.Queries.GetLeaderboard(ctx, db.GetLeaderboardParams{
 			GameID:     game.ID,
-			LimitCount: 100,
+			Limit: 100,
 		})
 		require.NoError(t, err)
 
@@ -399,7 +420,7 @@ func TestListPlayersWithBoards(t *testing.T) {
 		}
 
 		// Total should be 10 + 50 + 20 = 80
-		assertBoardTotalEqual(t, 80, row.BoardTotal)
+		verifiedPoints(t, 80, row)
 	})
 }
 
@@ -460,10 +481,18 @@ func TestPlayerBoardsFullWorkflow(t *testing.T) {
 	assertPgUUIDEqual(t, pgid(b2.ID), p.Board2ID)
 	assertPgUUIDEqual(t, pgid(b3.ID), p.Board3ID)
 
-	// Step 5: Check leaderboard total (10 + 20 + 30 = 60)
+	// Step 5: Update verified_points to sum of 3 boards (10+20+30=60).
+	err = env.Queries.UpdatePlayerAnalysis(ctx, db.UpdatePlayerAnalysisParams{
+		ID:             player.ID,
+		VerifiedPoints: 60,
+		AnalysisStatus: "complete",
+	})
+	require.NoError(t, err)
+
+	// Step 6: Check leaderboard (now 60 pts).
 	rows, err := env.Queries.GetLeaderboard(ctx, db.GetLeaderboardParams{
 		GameID:     game.ID,
-		LimitCount: 100,
+		Limit: 100,
 	})
 	require.NoError(t, err)
 	var row db.GetLeaderboardRow
@@ -473,7 +502,7 @@ func TestPlayerBoardsFullWorkflow(t *testing.T) {
 			break
 		}
 	}
-	assertBoardTotalEqual(t, 60, row.BoardTotal)
+	verifiedPoints(t, 60, row)
 
 	// Step 6: Replace one board (update only board_2)
 	pNew := testutil.CreateProject(t, env, "workflow-replace", "https://github.com/boardtest/replacement")
@@ -499,14 +528,22 @@ func TestPlayerBoardsFullWorkflow(t *testing.T) {
 	assertPgUUIDEqual(t, pgid(replaceBoard.ID), p.Board2ID)
 	assertPgUUIDEqual(t, pgid(b3.ID), p.Board3ID)
 
+	// Update verified_points to the new total (10+100+30=140).
+	err = env.Queries.UpdatePlayerAnalysis(ctx, db.UpdatePlayerAnalysisParams{
+		ID:             player.ID,
+		VerifiedPoints: 140,
+		AnalysisStatus: "complete",
+	})
+	require.NoError(t, err)
+
 	rows, err = env.Queries.GetLeaderboard(ctx, db.GetLeaderboardParams{
 		GameID:     game.ID,
-		LimitCount: 100,
+		Limit: 100,
 	})
 	require.NoError(t, err)
 	for _, r := range rows {
 		if r.ID == player.ID {
-			assertBoardTotalEqual(t, 140, r.BoardTotal)
+			verifiedPoints(t, 140, r)
 			return
 		}
 	}
@@ -525,16 +562,6 @@ func assertPgUUIDEqual(t *testing.T, expected pgtype.UUID, actual pgtype.UUID) {
 	assert.Equal(t, expected.Bytes, actual.Bytes)
 }
 
-func assertBoardTotalEqual(t *testing.T, expected int32, actual interface{}) {
-	t.Helper()
-	switch v := actual.(type) {
-	case int32:
-		assert.Equal(t, expected, v)
-	case int64:
-		assert.Equal(t, expected, int32(v))
-	case float64:
-		assert.InDelta(t, float64(expected), v, 0.001)
-	default:
-		t.Errorf("unexpected BoardTotal type %T", actual)
-	}
+func verifiedPoints(t *testing.T, expected int32, row db.GetLeaderboardRow) {
+	assert.Equal(t, expected, row.VerifiedPoints)
 }

--- a/internal/db/players.sql.go
+++ b/internal/db/players.sql.go
@@ -93,18 +93,9 @@ SELECT
     p.commit_count, p.project_count, p.analysis_status,
     p.last_analyzed_at, p.created_at, p.updated_at,
     p.board_1_id, p.board_2_id, p.board_3_id,
-    u.name, u.username, u.avatar_url,
-    COALESCE(board_total.total, 0) AS board_total
+    u.name, u.username, u.avatar_url
 FROM players p
 JOIN users u ON u.id = p.user_id AND p.game_id = $1 AND u.is_active = true
-LEFT JOIN LATERAL (
-    SELECT COALESCE(
-        SUM(CASE WHEN b.verified_points > 0 THEN b.verified_points ELSE b.points END),
-        0
-    )::int AS total
-    FROM boards b
-    WHERE b.id = ANY(ARRAY[p.board_1_id, p.board_2_id, p.board_3_id])
-) AS board_total ON true
 ORDER BY
     CASE WHEN p.verified_points > 0 THEN p.verified_points ELSE p.potential_points END DESC,
     p.points DESC
@@ -112,9 +103,9 @@ LIMIT $3 OFFSET $2
 `
 
 type GetLeaderboardParams struct {
-	GameID      uuid.UUID `json:"game_id"`
-	OffsetCount int32     `json:"offset_count"`
-	LimitCount  int32     `json:"limit_count"`
+	GameID uuid.UUID `json:"game_id"`
+	Offset int32     `json:"offset"`
+	Limit  int32     `json:"limit"`
 }
 
 type GetLeaderboardRow struct {
@@ -136,11 +127,10 @@ type GetLeaderboardRow struct {
 	Name            string             `json:"name"`
 	Username        string             `json:"username"`
 	AvatarUrl       pgtype.Text        `json:"avatar_url"`
-	BoardTotal      int32              `json:"board_total"`
 }
 
 func (q *Queries) GetLeaderboard(ctx context.Context, arg GetLeaderboardParams) ([]GetLeaderboardRow, error) {
-	rows, err := q.db.Query(ctx, getLeaderboard, arg.GameID, arg.OffsetCount, arg.LimitCount)
+	rows, err := q.db.Query(ctx, getLeaderboard, arg.GameID, arg.Offset, arg.Limit)
 	if err != nil {
 		return nil, err
 	}
@@ -167,7 +157,6 @@ func (q *Queries) GetLeaderboard(ctx context.Context, arg GetLeaderboardParams) 
 			&i.Name,
 			&i.Username,
 			&i.AvatarUrl,
-			&i.BoardTotal,
 		); err != nil {
 			return nil, err
 		}
@@ -222,6 +211,35 @@ func (q *Queries) GetPlayerBoardTotal(ctx context.Context, arg GetPlayerBoardTot
 	var total int32
 	err := row.Scan(&total)
 	return total, err
+}
+
+const getPlayerByBoardID = `-- name: GetPlayerByBoardID :one
+SELECT id, game_id, user_id, points, potential_points, verified_points, commit_count, project_count, analysis_status, last_analyzed_at, created_at, updated_at, board_1_id, board_2_id, board_3_id FROM players
+WHERE $1 = ANY(ARRAY[board_1_id, board_2_id, board_3_id])
+`
+
+// Returns the player who has the given board assigned (any of 3 slots).
+func (q *Queries) GetPlayerByBoardID(ctx context.Context, boardID pgtype.UUID) (Player, error) {
+	row := q.db.QueryRow(ctx, getPlayerByBoardID, boardID)
+	var i Player
+	err := row.Scan(
+		&i.ID,
+		&i.GameID,
+		&i.UserID,
+		&i.Points,
+		&i.PotentialPoints,
+		&i.VerifiedPoints,
+		&i.CommitCount,
+		&i.ProjectCount,
+		&i.AnalysisStatus,
+		&i.LastAnalyzedAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.Board1ID,
+		&i.Board2ID,
+		&i.Board3ID,
+	)
+	return i, err
 }
 
 const getPlayerByID = `-- name: GetPlayerByID :one
@@ -428,18 +446,28 @@ const updatePlayerAnalysis = `-- name: UpdatePlayerAnalysis :exec
 UPDATE players SET
     verified_points = $1,
     analysis_status = $2,
+    commit_count = $3,
+    project_count = $4,
     last_analyzed_at = now()
-WHERE id = $3
+WHERE id = $5
 `
 
 type UpdatePlayerAnalysisParams struct {
 	VerifiedPoints int32     `json:"verified_points"`
 	AnalysisStatus string    `json:"analysis_status"`
+	CommitCount    int32     `json:"commit_count"`
+	ProjectCount   int32     `json:"project_count"`
 	ID             uuid.UUID `json:"id"`
 }
 
 func (q *Queries) UpdatePlayerAnalysis(ctx context.Context, arg UpdatePlayerAnalysisParams) error {
-	_, err := q.db.Exec(ctx, updatePlayerAnalysis, arg.VerifiedPoints, arg.AnalysisStatus, arg.ID)
+	_, err := q.db.Exec(ctx, updatePlayerAnalysis,
+		arg.VerifiedPoints,
+		arg.AnalysisStatus,
+		arg.CommitCount,
+		arg.ProjectCount,
+		arg.ID,
+	)
 	return err
 }
 

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -95,6 +95,8 @@ type Querier interface {
 	// Return the sum of L1-scanned verified_points for all boards assigned
 	// to a player, falling back to initial points when unverified.
 	GetPlayerBoardTotal(ctx context.Context, arg GetPlayerBoardTotalParams) (int32, error)
+	// Returns the player who has the given board assigned (any of 3 slots).
+	GetPlayerByBoardID(ctx context.Context, boardID pgtype.UUID) (Player, error)
 	GetPlayerByID(ctx context.Context, id uuid.UUID) (Player, error)
 	GetPlayerByUserAndGame(ctx context.Context, arg GetPlayerByUserAndGameParams) (Player, error)
 	GetPlayerRank(ctx context.Context, arg GetPlayerRankParams) (int32, error)

--- a/internal/db/queries/players.sql
+++ b/internal/db/queries/players.sql
@@ -45,6 +45,8 @@ WHERE b.id IS NOT NULL;
 UPDATE players SET
     verified_points = @verified_points,
     analysis_status = @analysis_status,
+    commit_count = @commit_count,
+    project_count = @project_count,
     last_analyzed_at = now()
 WHERE id = @id;
 
@@ -55,22 +57,13 @@ SELECT
     p.commit_count, p.project_count, p.analysis_status,
     p.last_analyzed_at, p.created_at, p.updated_at,
     p.board_1_id, p.board_2_id, p.board_3_id,
-    u.name, u.username, u.avatar_url,
-    COALESCE(board_total.total, 0) AS board_total
+    u.name, u.username, u.avatar_url
 FROM players p
-JOIN users u ON u.id = p.user_id AND p.game_id = @game_id AND u.is_active = true
-LEFT JOIN LATERAL (
-    SELECT COALESCE(
-        SUM(CASE WHEN b.verified_points > 0 THEN b.verified_points ELSE b.points END),
-        0
-    )::int AS total
-    FROM boards b
-    WHERE b.id = ANY(ARRAY[p.board_1_id, p.board_2_id, p.board_3_id])
-) AS board_total ON true
+JOIN users u ON u.id = p.user_id AND p.game_id = $1 AND u.is_active = true
 ORDER BY
     CASE WHEN p.verified_points > 0 THEN p.verified_points ELSE p.potential_points END DESC,
     p.points DESC
-LIMIT @limit_count OFFSET @offset_count;
+LIMIT $3 OFFSET $2;
 
 -- name: GetPlayerRank :one
 SELECT COUNT(*) + 1 AS rank
@@ -133,3 +126,8 @@ SELECT COALESCE(
     ), 0)::int AS total
 FROM boards b
 WHERE b.id = @board_1_id OR b.id = @board_2_id OR b.id = @board_3_id;
+
+-- name: GetPlayerByBoardID :one
+-- Returns the player who has the given board assigned (any of 3 slots).
+SELECT * FROM players
+WHERE @board_id = ANY(ARRAY[board_1_id, board_2_id, board_3_id]);

--- a/internal/features/game/leaderboard.go
+++ b/internal/features/game/leaderboard.go
@@ -28,9 +28,9 @@ func (h *gameHandler) Leaders(w http.ResponseWriter, r *http.Request) {
 	stats, _ := h.queries.GetCommitStats(ctx, pgtype.UUID{Bytes: game.ID, Valid: true})
 
 	rows, err := h.queries.GetLeaderboard(ctx, db.GetLeaderboardParams{
-		GameID:      game.ID,
-		LimitCount:  int32(limit + 1),
-		OffsetCount: int32(offset),
+		GameID:  game.ID,
+		Limit:   int32(limit + 1),
+		Offset:  int32(offset),
 	})
 	if err != nil {
 		http.Error(w, "failed to load leaderboard", http.StatusInternalServerError)
@@ -56,7 +56,7 @@ func (h *gameHandler) Leaders(w http.ResponseWriter, r *http.Request) {
 			AvatarURL:    avatarURL,
 			CommitCount:  int(row.CommitCount),
 			ProjectCount: int(row.ProjectCount),
-			Points:       int(row.BoardTotal),
+			Points:       int(row.VerifiedPoints),
 		}
 	}
 

--- a/internal/metrics/service.go
+++ b/internal/metrics/service.go
@@ -10,19 +10,21 @@ import (
 	"github.com/rs/zerolog/log"
 
 	"july/internal/db"
+	"july/internal/services"
 )
 
 // Scanner runs server-side L1 analysis and upserts analysis_metrics rows.
 type Scanner struct {
-	queries *db.Queries
-	pool    *pgxpool.Pool
-	token   string
+	queries     *db.Queries
+	pool        *pgxpool.Pool
+	gameService *services.GameService
+	token       string
 }
 
 // NewScanner wires the app-wide queries handle and pool from the composition root (same as api.buildMux).
 // Pool is used only for transactions; queries is used for pool-scoped SQL (e.g. SetProjectIsPrivate).
-func NewScanner(queries *db.Queries, pool *pgxpool.Pool, token string) *Scanner {
-	return &Scanner{queries: queries, pool: pool, token: token}
+func NewScanner(queries *db.Queries, pool *pgxpool.Pool, gs *services.GameService, token string) *Scanner {
+	return &Scanner{queries: queries, pool: pool, gameService: gs, token: token}
 }
 
 // IsConfigured returns true when a non-empty GitHub token was provided (public-repo reads).
@@ -127,6 +129,14 @@ func (s *Scanner) RunScan(ctx context.Context, project db.Project, updatedBy uui
 			VerifiedPoints: int32(totalScore),
 		}); err != nil {
 			log.Warn().Err(err).Str("project", project.Slug).Msg("failed to update board verified_points")
+		}
+
+		// Refresh the player who owns this project's board.
+		game, err := s.gameService.GetActiveGame(ctx)
+		if err == nil {
+			if err := s.gameService.RefreshPlayerAfterScan(ctx, game.ID, project.ID); err != nil {
+				log.Warn().Err(err).Str("project", project.Slug).Msg("failed to refresh player after scan")
+			}
 		}
 	}
 

--- a/internal/services/game.go
+++ b/internal/services/game.go
@@ -347,6 +347,14 @@ func (s *GameService) assignPlayerBoards(ctx context.Context, game db.Game, user
 		}
 	}
 
+	counts, err := s.queries.CountUserCommitsForGame(ctx, db.CountUserCommitsForGameParams{
+		UserID: db.UUID(player.UserID),
+		GameID: db.UUID(game.ID),
+	})
+	if err != nil {
+		return fmt.Errorf("count commits: %w", err)
+	}
+
 	// Recalculate verified_points from all boards.
 	total, err := s.queries.GetPlayerBoardTotal(ctx, db.GetPlayerBoardTotalParams{
 		Board1ID: db.UUIDFromPg(ids.Board1ID),
@@ -357,9 +365,12 @@ func (s *GameService) assignPlayerBoards(ctx context.Context, game db.Game, user
 		return fmt.Errorf("get board total: %w", err)
 	}
 
+	verifiedPoints := int32(counts.CommitCount) + total
 	if err := s.queries.UpdatePlayerAnalysis(ctx, db.UpdatePlayerAnalysisParams{
 		ID:             player.ID,
-		VerifiedPoints: total,
+		VerifiedPoints: verifiedPoints,
+		CommitCount:    counts.CommitCount,
+		ProjectCount:   counts.ProjectCount,
 		AnalysisStatus: "completed",
 	}); err != nil {
 		return fmt.Errorf("update analysis: %w", err)
@@ -458,9 +469,9 @@ func (s *GameService) ApplyAnalysisAdjustment(ctx context.Context, playerID uuid
 // GetLeaderboard returns top players for a game.
 func (s *GameService) GetLeaderboard(ctx context.Context, gameID uuid.UUID, limit, offset int32) ([]db.GetLeaderboardRow, error) {
 	return s.queries.GetLeaderboard(ctx, db.GetLeaderboardParams{
-		GameID:      gameID,
-		LimitCount:  limit,
-		OffsetCount: offset,
+		GameID: gameID,
+		Limit:  limit,
+		Offset: offset,
 	})
 }
 
@@ -509,5 +520,61 @@ func (s *GameService) DeactivateProject(ctx context.Context, projectID uuid.UUID
 		return fmt.Errorf("deactivate project: %w", err)
 	}
 	logger.Info().Msg("deactivated project")
+	return nil
+}
+
+// RefreshPlayerAfterScan updates the player who owns the given project's board.
+// It recalculates verified_points = (commit_count × 1) + Sum(3 boards).
+func (s *GameService) RefreshPlayerAfterScan(ctx context.Context, gameID, projectID uuid.UUID) error {
+	// 1. Get the board for this project.
+	board, err := s.queries.GetBoardByProjectAndGame(ctx, db.GetBoardByProjectAndGameParams{
+		ProjectID: projectID,
+		GameID:    gameID,
+	})
+	if err != nil {
+		return nil // no board, skip silently
+	}
+
+	// 2. Find the player who has this board.
+	player, err := s.queries.GetPlayerByBoardID(ctx, db.UUID(board.ID))
+	if err != nil {
+		return nil // no player, skip silently
+	}
+
+	// 3. Get the user's commit count for the game.
+	counts, err := s.queries.CountUserCommitsForGame(ctx, db.CountUserCommitsForGameParams{
+		UserID: db.UUID(player.UserID),
+		GameID: db.UUID(gameID),
+	})
+	if err != nil {
+		return fmt.Errorf("count commits: %w", err)
+	}
+
+	// 4. Get the total from all 3 boards.
+	boardIDs, err := s.queries.GetPlayerBoardIds(ctx, player.ID)
+	if err != nil {
+		return fmt.Errorf("get board IDs: %w", err)
+	}
+
+	boardTotal, err := s.queries.GetPlayerBoardTotal(ctx, db.GetPlayerBoardTotalParams{
+		Board1ID: db.UUIDFromPg(boardIDs.Board1ID),
+		Board2ID: db.UUIDFromPg(boardIDs.Board2ID),
+		Board3ID: db.UUIDFromPg(boardIDs.Board3ID),
+	})
+	if err != nil {
+		return fmt.Errorf("get board total: %w", err)
+	}
+
+	// 5. Update the player: verified_points = commit_count + board_total.
+	verifiedPoints := int32(counts.CommitCount) + boardTotal
+	if err := s.queries.UpdatePlayerAnalysis(ctx, db.UpdatePlayerAnalysisParams{
+		ID:             player.ID,
+		VerifiedPoints: verifiedPoints,
+		CommitCount:    counts.CommitCount,
+		ProjectCount:   counts.ProjectCount,
+		AnalysisStatus: "completed",
+	}); err != nil {
+		return fmt.Errorf("update player: %w", err)
+	}
 	return nil
 }


### PR DESCRIPTION
- Add RefreshPlayerAfterScan to GameService that recalculates verified_points = commit_count + Sum(3 boards) for the affected player
- Hook into the L1 scan to call RefreshPlayerAfterScan after the board is updated (no player update happens during the scan itself)
- Simplify GetLeaderboard: removed the lateral join, leaderboard now reads p.verified_points directly — a plain int column on the player
- Added GetPlayerByBoardID SQL to find the player owning a board
- Updated NewScanner to accept a GameService reference
- Updated all tests to call UpdatePlayerAnalysis after board assignment

Closes: #234