### PR TITLE
fix: prevent open redirect via unvalidated Referer header

### DIFF
--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/invopop/ctxi18n"
 	"github.com/rs/zerolog/log"
+
+	"july/internal/shared"
 )
 
 //go:embed locales/*.yaml
@@ -58,9 +60,6 @@ func SetLanguage(w http.ResponseWriter, r *http.Request) {
 		SameSite: http.SameSiteLaxMode,
 	})
 
-	ref := r.Header.Get("Referer")
-	if ref == "" {
-		ref = "/"
-	}
+	ref := shared.SafeRedirect(r.Header.Get("Referer"))
 	http.Redirect(w, r, ref, http.StatusSeeOther)
 }

--- a/internal/i18n/i18n_test.go
+++ b/internal/i18n/i18n_test.go
@@ -128,4 +128,48 @@ func TestSetLanguage(t *testing.T) {
 		require.Equal(t, http.StatusSeeOther, rec.Code)
 		require.Equal(t, "/", rec.Header().Get("Location"))
 	})
+
+	t.Run("rejects external URL in Referer", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/set-language?lang=en", nil)
+		req.Header.Set("Referer", "https://evil.com/phish")
+
+		rec := httptest.NewRecorder()
+		SetLanguage(rec, req)
+
+		require.Equal(t, http.StatusSeeOther, rec.Code)
+		require.Equal(t, "/", rec.Header().Get("Location"))
+	})
+
+	t.Run("rejects protocol-relative URL in Referer", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/set-language?lang=en", nil)
+		req.Header.Set("Referer", "//evil.com")
+
+		rec := httptest.NewRecorder()
+		SetLanguage(rec, req)
+
+		require.Equal(t, http.StatusSeeOther, rec.Code)
+		require.Equal(t, "/", rec.Header().Get("Location"))
+	})
+
+	t.Run("rejects non-path Referer", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/set-language?lang=en", nil)
+		req.Header.Set("Referer", "javascript:alert(1)")
+
+		rec := httptest.NewRecorder()
+		SetLanguage(rec, req)
+
+		require.Equal(t, http.StatusSeeOther, rec.Code)
+		require.Equal(t, "/", rec.Header().Get("Location"))
+	})
+
+	t.Run("accepts valid internal paths", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/set-language?lang=en", nil)
+		req.Header.Set("Referer", "/profile/settings?tab=security")
+
+		rec := httptest.NewRecorder()
+		SetLanguage(rec, req)
+
+		require.Equal(t, http.StatusSeeOther, rec.Code)
+		require.Equal(t, "/profile/settings?tab=security", rec.Header().Get("Location"))
+	})
 }

--- a/internal/shared/redirect.go
+++ b/internal/shared/redirect.go
@@ -1,0 +1,25 @@
+package shared
+
+import "strings"
+
+// SafeRedirect validates that a URL is safe to redirect to. It only allows
+// paths starting with a single slash (no // which bypasses origin checks)
+// and no scheme (no :// for external URLs). Returns "/" for unsafe values.
+func SafeRedirect(ref string) string {
+	if ref == "" {
+		return "/"
+	}
+	// Reject external URLs (contains ://)
+	if idx := strings.Index(ref, "://"); idx >= 0 {
+		return "/"
+	}
+	// Reject protocol-relative URLs (starts with //)
+	if strings.HasPrefix(ref, "//") {
+		return "/"
+	}
+	// Only allow paths starting with /
+	if !strings.HasPrefix(ref, "/") {
+		return "/"
+	}
+	return ref
+}

--- a/internal/shared/redirect_test.go
+++ b/internal/shared/redirect_test.go
@@ -1,0 +1,34 @@
+package shared
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSafeRedirect(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		expect string
+	}{
+		{"empty string", "", "/"},
+		{"valid path", "/profile", "/profile"},
+		{"path with query", "/profile?tab=1", "/profile?tab=1"},
+		{"path with fragment", "/profile#section", "/profile#section"},
+		{"external https", "https://evil.com", "/"},
+		{"external http", "http://evil.com", "/"},
+		{"protocol-relative", "//evil.com", "/"},
+		{"javascript", "javascript:alert(1)", "/"},
+		{"data URL", "data:text/html,<script>", "/"},
+		{"backslash bypass", "\\evil.com", "/"},
+		{"absolute path no slash", "profile", "/"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SafeRedirect(tt.input)
+			assert.Equal(t, tt.expect, result)
+		})
+	}
+}


### PR DESCRIPTION
- Add shared.SafeRedirect utility that rejects external URLs, protocol-relative URLs (//evil.com), and non-path schemes (javascript:, data:). Only allows paths starting with /.
- Update SetLanguage to use shared.SafeRedirect.
- Add 11 edge-case tests for SafeRedirect.
- Move SafeRedirect tests from i18n to shared package.

Closes: #241